### PR TITLE
#105 FIX/TEST move nilearn to 0.7.1 and fix failed test

### DIFF
--- a/load_confounds/tests/test_parser.py
+++ b/load_confounds/tests/test_parser.py
@@ -170,14 +170,10 @@ def test_nilearn_standardize_psc():
 
     img, mask_conf, mask_rand, X = _simu_img(demean=False)
 
-    # Areas with
-    with pytest.warns(UserWarning) as records:
-        tseries_raw, tseries_clean = _denoise(img, mask_conf, X, "psc")
-
-    nilear_warning = sum('psc standardization strategy' in str(r.message) for r in records)
-    assert nilear_warning == 1
+    # Areas with confound
+    tseries_raw, tseries_clean = _denoise(img, mask_conf, X, "psc")
     corr = _corr_tseries(tseries_raw, tseries_clean)
-    assert not corr.mean() < 0.2  # expect failure
+    assert corr.mean() < 0.2
 
     # Areas with random noise
     tseries_raw, tseries_clean = _denoise(img, mask_rand, X, "psc")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.17.4
 pandas>=0.25.3
 scikit-learn>=0.21.3
 scipy>=1.3.2
-nilearn>=0.6.2
+nilearn>=0.7.1

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "pandas>=0.25.3",
         "scikit-learn>=0.21.3",
         "scipy>=1.3.2",
-        "nilearn>=0.6.2",
+        "nilearn>=0.7.1",
     ],  # external packages as dependencies
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Closes issue #105 

* Address issue introduced by new test data from PR #96
* revert the nilearn user warning check in `test_parser`

Nilearn has releasd a bug fix of 0.7.0. The bug fix release addressed
the problem with the PSC option in `nilearn.signal`.
PSC option now do normal mean centring and allow negative mean signals.