### PR TITLE
Iss78: properly handling multiple masks in anatCompCor

### DIFF
--- a/load_confounds/data/test_desc-confounds_regressors.json
+++ b/load_confounds/data/test_desc-confounds_regressors.json
@@ -1,0 +1,3884 @@
+{
+  "a_comp_cor_00": {
+    "CumulativeVarianceExplained": 0.0220653555,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 93.7782922477,
+    "VarianceExplained": 0.0220653555
+  },
+  "a_comp_cor_01": {
+    "CumulativeVarianceExplained": 0.0406977475,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 86.1749739572,
+    "VarianceExplained": 0.018632392
+  },
+  "a_comp_cor_02": {
+    "CumulativeVarianceExplained": 0.055822829,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 77.6418217369,
+    "VarianceExplained": 0.0151250815
+  },
+  "a_comp_cor_03": {
+    "CumulativeVarianceExplained": 0.0696926077,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 74.3501108977,
+    "VarianceExplained": 0.0138697787
+  },
+  "a_comp_cor_04": {
+    "CumulativeVarianceExplained": 0.0829624266,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 72.7242670652,
+    "VarianceExplained": 0.0132698189
+  },
+  "a_comp_cor_05": {
+    "CumulativeVarianceExplained": 0.0954876558,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 70.6544786992,
+    "VarianceExplained": 0.0125252292
+  },
+  "a_comp_cor_06": {
+    "CumulativeVarianceExplained": 0.1067884826,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 67.1122754845,
+    "VarianceExplained": 0.0113008268
+  },
+  "a_comp_cor_07": {
+    "CumulativeVarianceExplained": 0.1173738727,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 64.9531606675,
+    "VarianceExplained": 0.0105853901
+  },
+  "a_comp_cor_08": {
+    "CumulativeVarianceExplained": 0.1277909918,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 64.4348276011,
+    "VarianceExplained": 0.0104171191
+  },
+  "a_comp_cor_09": {
+    "CumulativeVarianceExplained": 0.1379595972,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 63.661600345,
+    "VarianceExplained": 0.0101686054
+  },
+  "a_comp_cor_10": {
+    "CumulativeVarianceExplained": 0.147881178,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 62.8835847593,
+    "VarianceExplained": 0.0099215808
+  },
+  "a_comp_cor_100": {
+    "CumulativeVarianceExplained": 0.312677849,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.7704044983,
+    "VarianceExplained": 0.00824055
+  },
+  "a_comp_cor_101": {
+    "CumulativeVarianceExplained": 0.3208656605,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.6140918626,
+    "VarianceExplained": 0.0081878116
+  },
+  "a_comp_cor_102": {
+    "CumulativeVarianceExplained": 0.3289817711,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.4007660384,
+    "VarianceExplained": 0.0081161106
+  },
+  "a_comp_cor_103": {
+    "CumulativeVarianceExplained": 0.3370569257,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.2784902377,
+    "VarianceExplained": 0.0080751546
+  },
+  "a_comp_cor_104": {
+    "CumulativeVarianceExplained": 0.3450862236,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.1412146283,
+    "VarianceExplained": 0.0080292979
+  },
+  "a_comp_cor_105": {
+    "CumulativeVarianceExplained": 0.3530763788,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.0237275573,
+    "VarianceExplained": 0.0079901552
+  },
+  "a_comp_cor_106": {
+    "CumulativeVarianceExplained": 0.3609840905,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 47.7753273888,
+    "VarianceExplained": 0.0079077117
+  },
+  "a_comp_cor_107": {
+    "CumulativeVarianceExplained": 0.3688742422,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 47.7222525068,
+    "VarianceExplained": 0.0078901517
+  },
+  "a_comp_cor_108": {
+    "CumulativeVarianceExplained": 0.3767238911,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 47.5996078044,
+    "VarianceExplained": 0.0078496489
+  },
+  "a_comp_cor_109": {
+    "CumulativeVarianceExplained": 0.3844982047,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 47.370643495,
+    "VarianceExplained": 0.0077743136
+  },
+  "a_comp_cor_11": {
+    "CumulativeVarianceExplained": 0.1574979874,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 61.9102219716,
+    "VarianceExplained": 0.0096168095
+  },
+  "a_comp_cor_110": {
+    "CumulativeVarianceExplained": 0.3922070631,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 47.1708054393,
+    "VarianceExplained": 0.0077088584
+  },
+  "a_comp_cor_111": {
+    "CumulativeVarianceExplained": 0.3998405716,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.9397049444,
+    "VarianceExplained": 0.0076335085
+  },
+  "a_comp_cor_112": {
+    "CumulativeVarianceExplained": 0.4074546995,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.8800797067,
+    "VarianceExplained": 0.0076141279
+  },
+  "a_comp_cor_113": {
+    "CumulativeVarianceExplained": 0.4150338693,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.7723376542,
+    "VarianceExplained": 0.0075791698
+  },
+  "a_comp_cor_114": {
+    "CumulativeVarianceExplained": 0.4225294588,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.5137285113,
+    "VarianceExplained": 0.0074955895
+  },
+  "a_comp_cor_115": {
+    "CumulativeVarianceExplained": 0.4299816479,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.3788731054,
+    "VarianceExplained": 0.0074521891
+  },
+  "a_comp_cor_116": {
+    "CumulativeVarianceExplained": 0.4373593901,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.1466304489,
+    "VarianceExplained": 0.0073777422
+  },
+  "a_comp_cor_117": {
+    "CumulativeVarianceExplained": 0.4447315441,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.1291507807,
+    "VarianceExplained": 0.0073721541
+  },
+  "a_comp_cor_118": {
+    "CumulativeVarianceExplained": 0.4520696998,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 46.0226602943,
+    "VarianceExplained": 0.0073381557
+  },
+  "a_comp_cor_119": {
+    "CumulativeVarianceExplained": 0.4593379718,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.8029914488,
+    "VarianceExplained": 0.007268272
+  },
+  "a_comp_cor_12": {
+    "CumulativeVarianceExplained": 0.1667271925,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 60.6497483894,
+    "VarianceExplained": 0.0092292051
+  },
+  "a_comp_cor_120": {
+    "CumulativeVarianceExplained": 0.466534632,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.5767922269,
+    "VarianceExplained": 0.0071966602
+  },
+  "a_comp_cor_121": {
+    "CumulativeVarianceExplained": 0.4737245311,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.5553782577,
+    "VarianceExplained": 0.0071898991
+  },
+  "a_comp_cor_122": {
+    "CumulativeVarianceExplained": 0.4808412267,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.3228751839,
+    "VarianceExplained": 0.0071166956
+  },
+  "a_comp_cor_123": {
+    "CumulativeVarianceExplained": 0.4879345926,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.2485261913,
+    "VarianceExplained": 0.0070933659
+  },
+  "a_comp_cor_124": {
+    "CumulativeVarianceExplained": 0.4950030287,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.168942917,
+    "VarianceExplained": 0.0070684361
+  },
+  "a_comp_cor_125": {
+    "CumulativeVarianceExplained": 0.501952694,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 44.787848831,
+    "VarianceExplained": 0.0069496653
+  },
+  "a_comp_cor_13": {
+    "CumulativeVarianceExplained": 0.1758480323,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 60.2926354045,
+    "VarianceExplained": 0.0091208397
+  },
+  "a_comp_cor_14": {
+    "CumulativeVarianceExplained": 0.184942118,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 60.2041429195,
+    "VarianceExplained": 0.0090940858
+  },
+  "a_comp_cor_15": {
+    "CumulativeVarianceExplained": 0.193833957,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 59.530927639,
+    "VarianceExplained": 0.008891839
+  },
+  "a_comp_cor_16": {
+    "CumulativeVarianceExplained": 0.2026005303,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 59.1101130948,
+    "VarianceExplained": 0.0087665733
+  },
+  "a_comp_cor_17": {
+    "CumulativeVarianceExplained": 0.2112880119,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 58.8428640884,
+    "VarianceExplained": 0.0086874816
+  },
+  "a_comp_cor_18": {
+    "CumulativeVarianceExplained": 0.2199214999,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 58.6597219657,
+    "VarianceExplained": 0.008633488
+  },
+  "a_comp_cor_19": {
+    "CumulativeVarianceExplained": 0.2285191586,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 58.537875204,
+    "VarianceExplained": 0.0085976587
+  },
+  "a_comp_cor_20": {
+    "CumulativeVarianceExplained": 0.237022194,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 58.2148587469,
+    "VarianceExplained": 0.0085030354
+  },
+  "a_comp_cor_21": {
+    "CumulativeVarianceExplained": 0.245451856,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 57.9631442233,
+    "VarianceExplained": 0.008429662
+  },
+  "a_comp_cor_22": {
+    "CumulativeVarianceExplained": 0.2538702975,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 57.9245549992,
+    "VarianceExplained": 0.0084184416
+  },
+  "a_comp_cor_23": {
+    "CumulativeVarianceExplained": 0.2621226595,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 57.350339023,
+    "VarianceExplained": 0.008252362
+  },
+  "a_comp_cor_24": {
+    "CumulativeVarianceExplained": 0.2702786493,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 57.014483211,
+    "VarianceExplained": 0.0081559898
+  },
+  "a_comp_cor_25": {
+    "CumulativeVarianceExplained": 0.2783896646,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.8570687188,
+    "VarianceExplained": 0.0081110153
+  },
+  "a_comp_cor_26": {
+    "CumulativeVarianceExplained": 0.2864499949,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.6791429266,
+    "VarianceExplained": 0.0080603303
+  },
+  "a_comp_cor_27": {
+    "CumulativeVarianceExplained": 0.2944767162,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.5608523827,
+    "VarianceExplained": 0.0080267213
+  },
+  "a_comp_cor_28": {
+    "CumulativeVarianceExplained": 0.3024484781,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.3668825842,
+    "VarianceExplained": 0.007971762
+  },
+  "a_comp_cor_29": {
+    "CumulativeVarianceExplained": 0.3103547353,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.1348185477,
+    "VarianceExplained": 0.0079062572
+  },
+  "a_comp_cor_30": {
+    "CumulativeVarianceExplained": 0.3182231641,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.0003657738,
+    "VarianceExplained": 0.0078684288
+  },
+  "a_comp_cor_31": {
+    "CumulativeVarianceExplained": 0.3260478941,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.8446451748,
+    "VarianceExplained": 0.00782473
+  },
+  "a_comp_cor_32": {
+    "CumulativeVarianceExplained": 0.3338501383,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.7643476406,
+    "VarianceExplained": 0.0078022442
+  },
+  "a_comp_cor_33": {
+    "CumulativeVarianceExplained": 0.3415725604,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.4783609114,
+    "VarianceExplained": 0.007722422
+  },
+  "a_comp_cor_34": {
+    "CumulativeVarianceExplained": 0.3492405364,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.282443279,
+    "VarianceExplained": 0.0076679761
+  },
+  "a_comp_cor_35": {
+    "CumulativeVarianceExplained": 0.3568540532,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.0857810068,
+    "VarianceExplained": 0.0076135168
+  },
+  "a_comp_cor_36": {
+    "CumulativeVarianceExplained": 0.3643979474,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.833333297,
+    "VarianceExplained": 0.0075438941
+  },
+  "a_comp_cor_37": {
+    "CumulativeVarianceExplained": 0.3718929922,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.6555127433,
+    "VarianceExplained": 0.0074950448
+  },
+  "a_comp_cor_38": {
+    "CumulativeVarianceExplained": 0.3793651239,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.5719049076,
+    "VarianceExplained": 0.0074721317
+  },
+  "a_comp_cor_39": {
+    "CumulativeVarianceExplained": 0.3868031539,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.4472336745,
+    "VarianceExplained": 0.00743803
+  },
+  "a_comp_cor_40": {
+    "CumulativeVarianceExplained": 0.3941797835,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.2220388299,
+    "VarianceExplained": 0.0073766296
+  },
+  "a_comp_cor_41": {
+    "CumulativeVarianceExplained": 0.401518962,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.0842211675,
+    "VarianceExplained": 0.0073391785
+  },
+  "a_comp_cor_42": {
+    "CumulativeVarianceExplained": 0.4088503179,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.0553899663,
+    "VarianceExplained": 0.0073313558
+  },
+  "a_comp_cor_43": {
+    "CumulativeVarianceExplained": 0.4161076659,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 53.7818613767,
+    "VarianceExplained": 0.007257348
+  },
+  "a_comp_cor_44": {
+    "CumulativeVarianceExplained": 0.4233189981,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 53.6110862586,
+    "VarianceExplained": 0.0072113322
+  },
+  "a_comp_cor_45": {
+    "CumulativeVarianceExplained": 0.4304653785,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 53.3691049188,
+    "VarianceExplained": 0.0071463804
+  },
+  "a_comp_cor_46": {
+    "CumulativeVarianceExplained": 0.4375629216,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 53.1864344012,
+    "VarianceExplained": 0.0070975432
+  },
+  "a_comp_cor_47": {
+    "CumulativeVarianceExplained": 0.444621288,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 53.0394429363,
+    "VarianceExplained": 0.0070583664
+  },
+  "a_comp_cor_48": {
+    "CumulativeVarianceExplained": 0.4516206436,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.8172621784,
+    "VarianceExplained": 0.0069993556
+  },
+  "a_comp_cor_49": {
+    "CumulativeVarianceExplained": 0.4586107918,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.7825106953,
+    "VarianceExplained": 0.0069901481
+  },
+  "a_comp_cor_50": {
+    "CumulativeVarianceExplained": 0.4655384539,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.5460657807,
+    "VarianceExplained": 0.0069276622
+  },
+  "a_comp_cor_51": {
+    "CumulativeVarianceExplained": 0.4724258638,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.3931873971,
+    "VarianceExplained": 0.0068874099
+  },
+  "a_comp_cor_52": {
+    "CumulativeVarianceExplained": 0.479289647,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.3032450614,
+    "VarianceExplained": 0.0068637832
+  },
+  "a_comp_cor_53": {
+    "CumulativeVarianceExplained": 0.4861024091,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.1084874189,
+    "VarianceExplained": 0.0068127621
+  },
+  "a_comp_cor_54": {
+    "CumulativeVarianceExplained": 0.4929055409,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.0716449468,
+    "VarianceExplained": 0.0068031318
+  },
+  "a_comp_cor_55": {
+    "CumulativeVarianceExplained": 0.4996363714,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.7942063307,
+    "VarianceExplained": 0.0067308305
+  },
+  "a_comp_cor_56": {
+    "CumulativeVarianceExplained": 0.5063540994,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.7437693473,
+    "VarianceExplained": 0.006717728
+  },
+  "a_comp_cor_57": {
+    "CumulativeVarianceExplained": 0.0854700111,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 91.7074102575,
+    "VarianceExplained": 0.0854700111
+  },
+  "a_comp_cor_58": {
+    "CumulativeVarianceExplained": 0.1627566581,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 87.2066858518,
+    "VarianceExplained": 0.0772866469
+  },
+  "a_comp_cor_59": {
+    "CumulativeVarianceExplained": 0.2284081941,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 80.3748166348,
+    "VarianceExplained": 0.0656515361
+  },
+  "a_comp_cor_60": {
+    "CumulativeVarianceExplained": 0.2741543026,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 67.0926007382,
+    "VarianceExplained": 0.0457461085
+  },
+  "a_comp_cor_61": {
+    "CumulativeVarianceExplained": 0.3148876528,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 63.3100438967,
+    "VarianceExplained": 0.0407333502
+  },
+  "a_comp_cor_62": {
+    "CumulativeVarianceExplained": 0.3507234193,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 59.3821473359,
+    "VarianceExplained": 0.0358357665
+  },
+  "a_comp_cor_63": {
+    "CumulativeVarianceExplained": 0.3847308143,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 57.8474517129,
+    "VarianceExplained": 0.034007395
+  },
+  "a_comp_cor_64": {
+    "CumulativeVarianceExplained": 0.4118041656,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.6141237274,
+    "VarianceExplained": 0.0270733513
+  },
+  "a_comp_cor_65": {
+    "CumulativeVarianceExplained": 0.4368888113,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 49.6822819423,
+    "VarianceExplained": 0.0250846457
+  },
+  "a_comp_cor_66": {
+    "CumulativeVarianceExplained": 0.4582812007,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 45.8804000713,
+    "VarianceExplained": 0.0213923893
+  },
+  "a_comp_cor_67": {
+    "CumulativeVarianceExplained": 0.4761198053,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 41.8965237432,
+    "VarianceExplained": 0.0178386047
+  },
+  "a_comp_cor_68": {
+    "CumulativeVarianceExplained": 0.4934302001,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 41.2715742243,
+    "VarianceExplained": 0.0173103947
+  },
+  "a_comp_cor_69": {
+    "CumulativeVarianceExplained": 0.5083783984,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 38.3523495704,
+    "VarianceExplained": 0.0149481983
+  },
+  "a_comp_cor_70": {
+    "CumulativeVarianceExplained": 0.0202826001,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 76.5138530016,
+    "VarianceExplained": 0.0202826001
+  },
+  "a_comp_cor_71": {
+    "CumulativeVarianceExplained": 0.0344955902,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 64.0502728266,
+    "VarianceExplained": 0.0142129901
+  },
+  "a_comp_cor_72": {
+    "CumulativeVarianceExplained": 0.0472040081,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 60.5653180187,
+    "VarianceExplained": 0.0127084179
+  },
+  "a_comp_cor_73": {
+    "CumulativeVarianceExplained": 0.0595971503,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 59.8093350501,
+    "VarianceExplained": 0.0123931422
+  },
+  "a_comp_cor_74": {
+    "CumulativeVarianceExplained": 0.0712591323,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 58.0182255795,
+    "VarianceExplained": 0.0116619821
+  },
+  "a_comp_cor_75": {
+    "CumulativeVarianceExplained": 0.0823733864,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 56.6393705084,
+    "VarianceExplained": 0.0111142541
+  },
+  "a_comp_cor_76": {
+    "CumulativeVarianceExplained": 0.0931794616,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.8485949025,
+    "VarianceExplained": 0.0108060752
+  },
+  "a_comp_cor_77": {
+    "CumulativeVarianceExplained": 0.1037858204,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 55.3300948919,
+    "VarianceExplained": 0.0106063588
+  },
+  "a_comp_cor_78": {
+    "CumulativeVarianceExplained": 0.1140735382,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.4926314003,
+    "VarianceExplained": 0.0102877178
+  },
+  "a_comp_cor_79": {
+    "CumulativeVarianceExplained": 0.1241919819,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 54.0424609478,
+    "VarianceExplained": 0.0101184437
+  },
+  "a_comp_cor_80": {
+    "CumulativeVarianceExplained": 0.1341598675,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 53.6388897246,
+    "VarianceExplained": 0.0099678856
+  },
+  "a_comp_cor_81": {
+    "CumulativeVarianceExplained": 0.1438076496,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.7705962313,
+    "VarianceExplained": 0.0096477821
+  },
+  "a_comp_cor_82": {
+    "CumulativeVarianceExplained": 0.1533330538,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.4348420594,
+    "VarianceExplained": 0.0095254042
+  },
+  "a_comp_cor_83": {
+    "CumulativeVarianceExplained": 0.1628329575,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.3646083367,
+    "VarianceExplained": 0.0094999037
+  },
+  "a_comp_cor_84": {
+    "CumulativeVarianceExplained": 0.1723128179,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 52.3093386016,
+    "VarianceExplained": 0.0094798604
+  },
+  "a_comp_cor_85": {
+    "CumulativeVarianceExplained": 0.1816600688,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.9421841715,
+    "VarianceExplained": 0.0093472509
+  },
+  "a_comp_cor_86": {
+    "CumulativeVarianceExplained": 0.1909603555,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.8115312046,
+    "VarianceExplained": 0.0093002867
+  },
+  "a_comp_cor_87": {
+    "CumulativeVarianceExplained": 0.2001117516,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.3951260012,
+    "VarianceExplained": 0.0091513961
+  },
+  "a_comp_cor_88": {
+    "CumulativeVarianceExplained": 0.2091710321,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.1358066237,
+    "VarianceExplained": 0.0090592805
+  },
+  "a_comp_cor_89": {
+    "CumulativeVarianceExplained": 0.2181828102,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 51.0015650367,
+    "VarianceExplained": 0.0090117781
+  },
+  "a_comp_cor_90": {
+    "CumulativeVarianceExplained": 0.2271234531,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 50.7998735937,
+    "VarianceExplained": 0.0089406429
+  },
+  "a_comp_cor_91": {
+    "CumulativeVarianceExplained": 0.2360262967,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 50.6923740753,
+    "VarianceExplained": 0.0089028436
+  },
+  "a_comp_cor_92": {
+    "CumulativeVarianceExplained": 0.2448719259,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 50.5292231267,
+    "VarianceExplained": 0.0088456291
+  },
+  "a_comp_cor_93": {
+    "CumulativeVarianceExplained": 0.2536855014,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 50.4375894944,
+    "VarianceExplained": 0.0088135755
+  },
+  "a_comp_cor_94": {
+    "CumulativeVarianceExplained": 0.2623730762,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 50.0757586762,
+    "VarianceExplained": 0.0086875749
+  },
+  "a_comp_cor_95": {
+    "CumulativeVarianceExplained": 0.2709762442,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 49.8319015442,
+    "VarianceExplained": 0.008603168
+  },
+  "a_comp_cor_96": {
+    "CumulativeVarianceExplained": 0.2794218689,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 49.3735264226,
+    "VarianceExplained": 0.0084456247
+  },
+  "a_comp_cor_97": {
+    "CumulativeVarianceExplained": 0.2878081666,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 49.1998065137,
+    "VarianceExplained": 0.0083862977
+  },
+  "a_comp_cor_98": {
+    "CumulativeVarianceExplained": 0.2961502804,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 49.0700288945,
+    "VarianceExplained": 0.0083421138
+  },
+  "a_comp_cor_99": {
+    "CumulativeVarianceExplained": 0.304437299,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": true,
+    "SingularValue": 48.9077195547,
+    "VarianceExplained": 0.0082870185
+  },
+  "dropped_0": {
+    "CumulativeVarianceExplained": 0.5130294166,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 51.5801745582,
+    "VarianceExplained": 0.0066753172
+  },
+  "dropped_1": {
+    "CumulativeVarianceExplained": 0.5196592005,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 51.4039558578,
+    "VarianceExplained": 0.0066297839
+  },
+  "dropped_10": {
+    "CumulativeVarianceExplained": 0.5776068408,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.0450450866,
+    "VarianceExplained": 0.0062838883
+  },
+  "dropped_100": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_101": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_102": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_103": {
+    "CumulativeVarianceExplained": 0.5204348012,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.4434323691,
+    "VarianceExplained": 0.0120564028
+  },
+  "dropped_104": {
+    "CumulativeVarianceExplained": 0.5316923354,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.2827488603,
+    "VarianceExplained": 0.0112575343
+  },
+  "dropped_105": {
+    "CumulativeVarianceExplained": 0.5423790044,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.4278926443,
+    "VarianceExplained": 0.0106866689
+  },
+  "dropped_106": {
+    "CumulativeVarianceExplained": 0.5521179909,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.9566838421,
+    "VarianceExplained": 0.0097389865
+  },
+  "dropped_107": {
+    "CumulativeVarianceExplained": 0.5616744336,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.6651913918,
+    "VarianceExplained": 0.0095564427
+  },
+  "dropped_108": {
+    "CumulativeVarianceExplained": 0.5709420086,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.1981684211,
+    "VarianceExplained": 0.009267575
+  },
+  "dropped_109": {
+    "CumulativeVarianceExplained": 0.5791960723,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 28.4991204782,
+    "VarianceExplained": 0.0082540637
+  },
+  "dropped_11": {
+    "CumulativeVarianceExplained": 0.5838647785,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.9416022502,
+    "VarianceExplained": 0.0062579377
+  },
+  "dropped_110": {
+    "CumulativeVarianceExplained": 0.5872661029,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 28.1796205679,
+    "VarianceExplained": 0.0080700306
+  },
+  "dropped_111": {
+    "CumulativeVarianceExplained": 0.5950543383,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 27.6832505606,
+    "VarianceExplained": 0.0077882354
+  },
+  "dropped_112": {
+    "CumulativeVarianceExplained": 0.6027899448,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 27.5895574309,
+    "VarianceExplained": 0.0077356065
+  },
+  "dropped_113": {
+    "CumulativeVarianceExplained": 0.6103972515,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 27.3598059766,
+    "VarianceExplained": 0.0076073067
+  },
+  "dropped_114": {
+    "CumulativeVarianceExplained": 0.6175837765,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 26.5923683722,
+    "VarianceExplained": 0.007186525
+  },
+  "dropped_115": {
+    "CumulativeVarianceExplained": 0.6244972518,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 26.0822923635,
+    "VarianceExplained": 0.0069134754
+  },
+  "dropped_116": {
+    "CumulativeVarianceExplained": 0.6313045532,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 25.8812374487,
+    "VarianceExplained": 0.0068073013
+  },
+  "dropped_117": {
+    "CumulativeVarianceExplained": 0.6379232302,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 25.5201453214,
+    "VarianceExplained": 0.006618677
+  },
+  "dropped_118": {
+    "CumulativeVarianceExplained": 0.6443729578,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 25.1923241471,
+    "VarianceExplained": 0.0064497276
+  },
+  "dropped_119": {
+    "CumulativeVarianceExplained": 0.6507286589,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 25.0080184868,
+    "VarianceExplained": 0.0063557011
+  },
+  "dropped_12": {
+    "CumulativeVarianceExplained": 0.5900911391,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.8154423175,
+    "VarianceExplained": 0.0062263606
+  },
+  "dropped_120": {
+    "CumulativeVarianceExplained": 0.6568649116,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 24.5724901243,
+    "VarianceExplained": 0.0061362528
+  },
+  "dropped_121": {
+    "CumulativeVarianceExplained": 0.6629618573,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 24.4936614269,
+    "VarianceExplained": 0.0060969456
+  },
+  "dropped_122": {
+    "CumulativeVarianceExplained": 0.6689410243,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 24.2559277834,
+    "VarianceExplained": 0.005979167
+  },
+  "dropped_123": {
+    "CumulativeVarianceExplained": 0.6748500583,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 24.1132525497,
+    "VarianceExplained": 0.005909034
+  },
+  "dropped_124": {
+    "CumulativeVarianceExplained": 0.680601192,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 23.7888957364,
+    "VarianceExplained": 0.0057511337
+  },
+  "dropped_125": {
+    "CumulativeVarianceExplained": 0.6861966931,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 23.464809965,
+    "VarianceExplained": 0.0055955011
+  },
+  "dropped_126": {
+    "CumulativeVarianceExplained": 0.6916873587,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 23.2439559476,
+    "VarianceExplained": 0.0054906655
+  },
+  "dropped_127": {
+    "CumulativeVarianceExplained": 0.697116045,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 23.1123935384,
+    "VarianceExplained": 0.0054286863
+  },
+  "dropped_128": {
+    "CumulativeVarianceExplained": 0.7024833025,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 22.9812562992,
+    "VarianceExplained": 0.0053672575
+  },
+  "dropped_129": {
+    "CumulativeVarianceExplained": 0.7077485031,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 22.7617165606,
+    "VarianceExplained": 0.0052652006
+  },
+  "dropped_13": {
+    "CumulativeVarianceExplained": 0.5963007347,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.7483309341,
+    "VarianceExplained": 0.0062095956
+  },
+  "dropped_130": {
+    "CumulativeVarianceExplained": 0.7129562676,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 22.6372265889,
+    "VarianceExplained": 0.0052077645
+  },
+  "dropped_131": {
+    "CumulativeVarianceExplained": 0.7180463466,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 22.3799859537,
+    "VarianceExplained": 0.005090079
+  },
+  "dropped_132": {
+    "CumulativeVarianceExplained": 0.7231054454,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 22.3117754741,
+    "VarianceExplained": 0.0050590988
+  },
+  "dropped_133": {
+    "CumulativeVarianceExplained": 0.7280335976,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 22.0211300095,
+    "VarianceExplained": 0.0049281521
+  },
+  "dropped_134": {
+    "CumulativeVarianceExplained": 0.7328721569,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 21.820042175,
+    "VarianceExplained": 0.0048385594
+  },
+  "dropped_135": {
+    "CumulativeVarianceExplained": 0.7376493487,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 21.681228608,
+    "VarianceExplained": 0.0047771918
+  },
+  "dropped_136": {
+    "CumulativeVarianceExplained": 0.7423153368,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 21.4273943405,
+    "VarianceExplained": 0.0046659881
+  },
+  "dropped_137": {
+    "CumulativeVarianceExplained": 0.746917784,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 21.2809962164,
+    "VarianceExplained": 0.0046024472
+  },
+  "dropped_138": {
+    "CumulativeVarianceExplained": 0.7514574168,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 21.1352755842,
+    "VarianceExplained": 0.0045396329
+  },
+  "dropped_139": {
+    "CumulativeVarianceExplained": 0.7559680084,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 21.0675630546,
+    "VarianceExplained": 0.0045105916
+  },
+  "dropped_14": {
+    "CumulativeVarianceExplained": 0.602476355,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.6120469609,
+    "VarianceExplained": 0.0061756202
+  },
+  "dropped_140": {
+    "CumulativeVarianceExplained": 0.7604225781,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.936323965,
+    "VarianceExplained": 0.0044545697
+  },
+  "dropped_141": {
+    "CumulativeVarianceExplained": 0.764864259,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.9060134634,
+    "VarianceExplained": 0.0044416809
+  },
+  "dropped_142": {
+    "CumulativeVarianceExplained": 0.7691488111,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.5328985989,
+    "VarianceExplained": 0.0042845521
+  },
+  "dropped_143": {
+    "CumulativeVarianceExplained": 0.7733435251,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.3164921391,
+    "VarianceExplained": 0.004194714
+  },
+  "dropped_144": {
+    "CumulativeVarianceExplained": 0.7774920468,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.204319881,
+    "VarianceExplained": 0.0041485218
+  },
+  "dropped_145": {
+    "CumulativeVarianceExplained": 0.7815781539,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 20.0517563971,
+    "VarianceExplained": 0.0040861071
+  },
+  "dropped_146": {
+    "CumulativeVarianceExplained": 0.7855986979,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.8902371405,
+    "VarianceExplained": 0.004020544
+  },
+  "dropped_147": {
+    "CumulativeVarianceExplained": 0.7896167837,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.8841554617,
+    "VarianceExplained": 0.0040180858
+  },
+  "dropped_148": {
+    "CumulativeVarianceExplained": 0.7935224755,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.6040831539,
+    "VarianceExplained": 0.0039056918
+  },
+  "dropped_149": {
+    "CumulativeVarianceExplained": 0.7974155861,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.5724827784,
+    "VarianceExplained": 0.0038931106
+  },
+  "dropped_15": {
+    "CumulativeVarianceExplained": 0.6085935283,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.3767214461,
+    "VarianceExplained": 0.0061171734
+  },
+  "dropped_150": {
+    "CumulativeVarianceExplained": 0.8012306693,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.3753500018,
+    "VarianceExplained": 0.0038150832
+  },
+  "dropped_151": {
+    "CumulativeVarianceExplained": 0.8049865255,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.2243660237,
+    "VarianceExplained": 0.0037558562
+  },
+  "dropped_152": {
+    "CumulativeVarianceExplained": 0.8087180201,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.1619170693,
+    "VarianceExplained": 0.0037314946
+  },
+  "dropped_153": {
+    "CumulativeVarianceExplained": 0.8124130702,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.0681129424,
+    "VarianceExplained": 0.0036950501
+  },
+  "dropped_154": {
+    "CumulativeVarianceExplained": 0.816086846,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 19.0131411369,
+    "VarianceExplained": 0.0036737758
+  },
+  "dropped_155": {
+    "CumulativeVarianceExplained": 0.8197238619,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.9177792285,
+    "VarianceExplained": 0.003637016
+  },
+  "dropped_156": {
+    "CumulativeVarianceExplained": 0.8232984162,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.7546298368,
+    "VarianceExplained": 0.0035745543
+  },
+  "dropped_157": {
+    "CumulativeVarianceExplained": 0.8268476633,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.6881223183,
+    "VarianceExplained": 0.0035492471
+  },
+  "dropped_158": {
+    "CumulativeVarianceExplained": 0.8303657019,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.6057786814,
+    "VarianceExplained": 0.0035180386
+  },
+  "dropped_159": {
+    "CumulativeVarianceExplained": 0.8338462571,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.5063943671,
+    "VarianceExplained": 0.0034805552
+  },
+  "dropped_16": {
+    "CumulativeVarianceExplained": 0.614691898,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.3007727968,
+    "VarianceExplained": 0.0060983696
+  },
+  "dropped_160": {
+    "CumulativeVarianceExplained": 0.8372983047,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.4304497788,
+    "VarianceExplained": 0.0034520476
+  },
+  "dropped_161": {
+    "CumulativeVarianceExplained": 0.8406200683,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 18.0793124946,
+    "VarianceExplained": 0.0033217636
+  },
+  "dropped_162": {
+    "CumulativeVarianceExplained": 0.8439027368,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.9726064649,
+    "VarianceExplained": 0.0032826685
+  },
+  "dropped_163": {
+    "CumulativeVarianceExplained": 0.8471618629,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.9080431311,
+    "VarianceExplained": 0.0032591261
+  },
+  "dropped_164": {
+    "CumulativeVarianceExplained": 0.8503810493,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.7979757647,
+    "VarianceExplained": 0.0032191864
+  },
+  "dropped_165": {
+    "CumulativeVarianceExplained": 0.8535447909,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.6440406345,
+    "VarianceExplained": 0.0031637416
+  },
+  "dropped_166": {
+    "CumulativeVarianceExplained": 0.8566707758,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.5384410237,
+    "VarianceExplained": 0.0031259849
+  },
+  "dropped_167": {
+    "CumulativeVarianceExplained": 0.8597502129,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.4073724409,
+    "VarianceExplained": 0.0030794371
+  },
+  "dropped_168": {
+    "CumulativeVarianceExplained": 0.8627710746,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.2410205644,
+    "VarianceExplained": 0.0030208617
+  },
+  "dropped_169": {
+    "CumulativeVarianceExplained": 0.8657570502,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 17.1411783946,
+    "VarianceExplained": 0.0029859756
+  },
+  "dropped_17": {
+    "CumulativeVarianceExplained": 0.6207529621,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 49.14974806,
+    "VarianceExplained": 0.0060610642
+  },
+  "dropped_170": {
+    "CumulativeVarianceExplained": 0.86868703,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.9796941256,
+    "VarianceExplained": 0.0029299798
+  },
+  "dropped_171": {
+    "CumulativeVarianceExplained": 0.8716004281,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.9315791926,
+    "VarianceExplained": 0.0029133981
+  },
+  "dropped_172": {
+    "CumulativeVarianceExplained": 0.8744639929,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.786148281,
+    "VarianceExplained": 0.0028635648
+  },
+  "dropped_173": {
+    "CumulativeVarianceExplained": 0.8773097901,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.7339908193,
+    "VarianceExplained": 0.0028457972
+  },
+  "dropped_174": {
+    "CumulativeVarianceExplained": 0.8801127502,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.6075665486,
+    "VarianceExplained": 0.00280296
+  },
+  "dropped_175": {
+    "CumulativeVarianceExplained": 0.8828850027,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.5163448348,
+    "VarianceExplained": 0.0027722525
+  },
+  "dropped_176": {
+    "CumulativeVarianceExplained": 0.8856383001,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.4597833906,
+    "VarianceExplained": 0.0027532975
+  },
+  "dropped_177": {
+    "CumulativeVarianceExplained": 0.8882838634,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.1345414283,
+    "VarianceExplained": 0.0026455633
+  },
+  "dropped_178": {
+    "CumulativeVarianceExplained": 0.8909198058,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.1051771804,
+    "VarianceExplained": 0.0026359424
+  },
+  "dropped_179": {
+    "CumulativeVarianceExplained": 0.8935258446,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 16.0135634802,
+    "VarianceExplained": 0.0026060388
+  },
+  "dropped_18": {
+    "CumulativeVarianceExplained": 0.6267768686,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.9988586315,
+    "VarianceExplained": 0.0060239064
+  },
+  "dropped_180": {
+    "CumulativeVarianceExplained": 0.8961089016,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.9427981812,
+    "VarianceExplained": 0.0025830571
+  },
+  "dropped_181": {
+    "CumulativeVarianceExplained": 0.8986350333,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.7661460133,
+    "VarianceExplained": 0.0025261317
+  },
+  "dropped_182": {
+    "CumulativeVarianceExplained": 0.9011262797,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.6569040175,
+    "VarianceExplained": 0.0024912464
+  },
+  "dropped_183": {
+    "CumulativeVarianceExplained": 0.9036049912,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.6174647485,
+    "VarianceExplained": 0.0024787114
+  },
+  "dropped_184": {
+    "CumulativeVarianceExplained": 0.9060306148,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.4493159587,
+    "VarianceExplained": 0.0024256236
+  },
+  "dropped_185": {
+    "CumulativeVarianceExplained": 0.9084357208,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.383836866,
+    "VarianceExplained": 0.0024051061
+  },
+  "dropped_186": {
+    "CumulativeVarianceExplained": 0.9107687458,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.1515560892,
+    "VarianceExplained": 0.0023330249
+  },
+  "dropped_187": {
+    "CumulativeVarianceExplained": 0.9130993894,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.1438215267,
+    "VarianceExplained": 0.0023306436
+  },
+  "dropped_188": {
+    "CumulativeVarianceExplained": 0.9154071743,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 15.0693742753,
+    "VarianceExplained": 0.002307785
+  },
+  "dropped_189": {
+    "CumulativeVarianceExplained": 0.9176934297,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.9989174313,
+    "VarianceExplained": 0.0022862553
+  },
+  "dropped_19": {
+    "CumulativeVarianceExplained": 0.6327973379,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.984877969,
+    "VarianceExplained": 0.0060204694
+  },
+  "dropped_190": {
+    "CumulativeVarianceExplained": 0.9199512072,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.9052109926,
+    "VarianceExplained": 0.0022577776
+  },
+  "dropped_191": {
+    "CumulativeVarianceExplained": 0.9221571184,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.7330124177,
+    "VarianceExplained": 0.0022059111
+  },
+  "dropped_192": {
+    "CumulativeVarianceExplained": 0.924356791,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.7121645435,
+    "VarianceExplained": 0.0021996726
+  },
+  "dropped_193": {
+    "CumulativeVarianceExplained": 0.9265340216,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.636922186,
+    "VarianceExplained": 0.0021772306
+  },
+  "dropped_194": {
+    "CumulativeVarianceExplained": 0.9286663772,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.4852958631,
+    "VarianceExplained": 0.0021323557
+  },
+  "dropped_195": {
+    "CumulativeVarianceExplained": 0.9307840792,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.4354382093,
+    "VarianceExplained": 0.002117702
+  },
+  "dropped_196": {
+    "CumulativeVarianceExplained": 0.9328358972,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.2091129942,
+    "VarianceExplained": 0.002051818
+  },
+  "dropped_197": {
+    "CumulativeVarianceExplained": 0.9348505789,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.0799388666,
+    "VarianceExplained": 0.0020146817
+  },
+  "dropped_198": {
+    "CumulativeVarianceExplained": 0.9368527538,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 14.0361679514,
+    "VarianceExplained": 0.0020021749
+  },
+  "dropped_199": {
+    "CumulativeVarianceExplained": 0.9388111484,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.8818597108,
+    "VarianceExplained": 0.0019583946
+  },
+  "dropped_2": {
+    "CumulativeVarianceExplained": 0.5262508782,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 51.2560148947,
+    "VarianceExplained": 0.0065916777
+  },
+  "dropped_20": {
+    "CumulativeVarianceExplained": 0.6387662641,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.7747396367,
+    "VarianceExplained": 0.0059689262
+  },
+  "dropped_200": {
+    "CumulativeVarianceExplained": 0.940747576,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.8037846074,
+    "VarianceExplained": 0.0019364275
+  },
+  "dropped_201": {
+    "CumulativeVarianceExplained": 0.9426565568,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.7056087236,
+    "VarianceExplained": 0.0019089808
+  },
+  "dropped_202": {
+    "CumulativeVarianceExplained": 0.9445224191,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.549939206,
+    "VarianceExplained": 0.0018658623
+  },
+  "dropped_203": {
+    "CumulativeVarianceExplained": 0.9463786826,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.5150407387,
+    "VarianceExplained": 0.0018562635
+  },
+  "dropped_204": {
+    "CumulativeVarianceExplained": 0.9482027122,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.3971831409,
+    "VarianceExplained": 0.0018240296
+  },
+  "dropped_205": {
+    "CumulativeVarianceExplained": 0.9499905068,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.2634454077,
+    "VarianceExplained": 0.0017877946
+  },
+  "dropped_206": {
+    "CumulativeVarianceExplained": 0.9517493561,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.1556366606,
+    "VarianceExplained": 0.0017588493
+  },
+  "dropped_207": {
+    "CumulativeVarianceExplained": 0.9534764769,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 13.0364368999,
+    "VarianceExplained": 0.0017271208
+  },
+  "dropped_208": {
+    "CumulativeVarianceExplained": 0.955185268,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.9670754872,
+    "VarianceExplained": 0.0017087911
+  },
+  "dropped_209": {
+    "CumulativeVarianceExplained": 0.9568721016,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.883493986,
+    "VarianceExplained": 0.0016868335
+  },
+  "dropped_21": {
+    "CumulativeVarianceExplained": 0.6446993927,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.6282607368,
+    "VarianceExplained": 0.0059331286
+  },
+  "dropped_210": {
+    "CumulativeVarianceExplained": 0.9585505343,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.8513728018,
+    "VarianceExplained": 0.0016784328
+  },
+  "dropped_211": {
+    "CumulativeVarianceExplained": 0.9602003647,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.7414013766,
+    "VarianceExplained": 0.0016498304
+  },
+  "dropped_212": {
+    "CumulativeVarianceExplained": 0.9618137281,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.5998000736,
+    "VarianceExplained": 0.0016133634
+  },
+  "dropped_213": {
+    "CumulativeVarianceExplained": 0.9634163672,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.557853518,
+    "VarianceExplained": 0.0016026391
+  },
+  "dropped_214": {
+    "CumulativeVarianceExplained": 0.9650140966,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.5386034479,
+    "VarianceExplained": 0.0015977294
+  },
+  "dropped_215": {
+    "CumulativeVarianceExplained": 0.96656455,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.3517048347,
+    "VarianceExplained": 0.0015504534
+  },
+  "dropped_216": {
+    "CumulativeVarianceExplained": 0.9680880552,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.24389269,
+    "VarianceExplained": 0.0015235052
+  },
+  "dropped_217": {
+    "CumulativeVarianceExplained": 0.9695948402,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.1765204001,
+    "VarianceExplained": 0.0015067851
+  },
+  "dropped_218": {
+    "CumulativeVarianceExplained": 0.9710914251,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.1352358395,
+    "VarianceExplained": 0.0014965848
+  },
+  "dropped_219": {
+    "CumulativeVarianceExplained": 0.9725556421,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 12.0032894679,
+    "VarianceExplained": 0.0014642171
+  },
+  "dropped_22": {
+    "CumulativeVarianceExplained": 0.6506023031,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.5042671939,
+    "VarianceExplained": 0.0059029103
+  },
+  "dropped_220": {
+    "CumulativeVarianceExplained": 0.9739739045,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.8134252414,
+    "VarianceExplained": 0.0014182624
+  },
+  "dropped_221": {
+    "CumulativeVarianceExplained": 0.9753553395,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.6590397092,
+    "VarianceExplained": 0.001381435
+  },
+  "dropped_222": {
+    "CumulativeVarianceExplained": 0.9767252922,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.6104842193,
+    "VarianceExplained": 0.0013699527
+  },
+  "dropped_223": {
+    "CumulativeVarianceExplained": 0.9780286697,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.3248552982,
+    "VarianceExplained": 0.0013033775
+  },
+  "dropped_224": {
+    "CumulativeVarianceExplained": 0.9793264664,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.3005838571,
+    "VarianceExplained": 0.0012977967
+  },
+  "dropped_225": {
+    "CumulativeVarianceExplained": 0.980613701,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.254504886,
+    "VarianceExplained": 0.0012872346
+  },
+  "dropped_226": {
+    "CumulativeVarianceExplained": 0.9818830554,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 11.1760669749,
+    "VarianceExplained": 0.0012693544
+  },
+  "dropped_227": {
+    "CumulativeVarianceExplained": 0.9831075493,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.9768031326,
+    "VarianceExplained": 0.001224494
+  },
+  "dropped_228": {
+    "CumulativeVarianceExplained": 0.98432556,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.9477054384,
+    "VarianceExplained": 0.0012180107
+  },
+  "dropped_229": {
+    "CumulativeVarianceExplained": 0.9855306921,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.8896735837,
+    "VarianceExplained": 0.001205132
+  },
+  "dropped_23": {
+    "CumulativeVarianceExplained": 0.6564967334,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.4694146708,
+    "VarianceExplained": 0.0058944303
+  },
+  "dropped_230": {
+    "CumulativeVarianceExplained": 0.9867016144,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.7340000116,
+    "VarianceExplained": 0.0011709223
+  },
+  "dropped_231": {
+    "CumulativeVarianceExplained": 0.9878401029,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.5842933894,
+    "VarianceExplained": 0.0011384885
+  },
+  "dropped_232": {
+    "CumulativeVarianceExplained": 0.9889641579,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.5169868542,
+    "VarianceExplained": 0.001124055
+  },
+  "dropped_233": {
+    "CumulativeVarianceExplained": 0.9900360608,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.2701142244,
+    "VarianceExplained": 0.0010719029
+  },
+  "dropped_234": {
+    "CumulativeVarianceExplained": 0.9910753991,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 10.1129071626,
+    "VarianceExplained": 0.0010393383
+  },
+  "dropped_235": {
+    "CumulativeVarianceExplained": 0.9920891652,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.9877216302,
+    "VarianceExplained": 0.0010137661
+  },
+  "dropped_236": {
+    "CumulativeVarianceExplained": 0.9930862454,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.9051848695,
+    "VarianceExplained": 0.0009970802
+  },
+  "dropped_237": {
+    "CumulativeVarianceExplained": 0.9940416297,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.6958661962,
+    "VarianceExplained": 0.0009553844
+  },
+  "dropped_238": {
+    "CumulativeVarianceExplained": 0.9949874985,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.6474600474,
+    "VarianceExplained": 0.0009458688
+  },
+  "dropped_239": {
+    "CumulativeVarianceExplained": 0.9958883211,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.4149323634,
+    "VarianceExplained": 0.0009008227
+  },
+  "dropped_24": {
+    "CumulativeVarianceExplained": 0.6623139512,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.1509119197,
+    "VarianceExplained": 0.0058172178
+  },
+  "dropped_240": {
+    "CumulativeVarianceExplained": 0.9967696935,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.3127353759,
+    "VarianceExplained": 0.0008813724
+  },
+  "dropped_241": {
+    "CumulativeVarianceExplained": 0.9976342151,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.2232816018,
+    "VarianceExplained": 0.0008645216
+  },
+  "dropped_242": {
+    "CumulativeVarianceExplained": 0.9984770219,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 9.1067114296,
+    "VarianceExplained": 0.0008428068
+  },
+  "dropped_243": {
+    "CumulativeVarianceExplained": 0.9992564938,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 8.7578557153,
+    "VarianceExplained": 0.0007794719
+  },
+  "dropped_244": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 8.5534206888,
+    "VarianceExplained": 0.0007435062
+  },
+  "dropped_245": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_246": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_247": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_248": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_249": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "CSF",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_25": {
+    "CumulativeVarianceExplained": 0.6681012684,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 48.0270041946,
+    "VarianceExplained": 0.0057873172
+  },
+  "dropped_250": {
+    "CumulativeVarianceExplained": 0.5088963321,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.7684228151,
+    "VarianceExplained": 0.006943638
+  },
+  "dropped_251": {
+    "CumulativeVarianceExplained": 0.5157960352,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.6265650547,
+    "VarianceExplained": 0.0068997031
+  },
+  "dropped_252": {
+    "CumulativeVarianceExplained": 0.5226536544,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.4902598068,
+    "VarianceExplained": 0.0068576192
+  },
+  "dropped_253": {
+    "CumulativeVarianceExplained": 0.5294767144,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.3780129398,
+    "VarianceExplained": 0.00682306
+  },
+  "dropped_254": {
+    "CumulativeVarianceExplained": 0.5362551262,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.2325759986,
+    "VarianceExplained": 0.0067784118
+  },
+  "dropped_255": {
+    "CumulativeVarianceExplained": 0.5429764254,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.0458375569,
+    "VarianceExplained": 0.0067212992
+  },
+  "dropped_256": {
+    "CumulativeVarianceExplained": 0.5496741872,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.9686474025,
+    "VarianceExplained": 0.0066977618
+  },
+  "dropped_257": {
+    "CumulativeVarianceExplained": 0.5563522271,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.9038660325,
+    "VarianceExplained": 0.00667804
+  },
+  "dropped_258": {
+    "CumulativeVarianceExplained": 0.5629603039,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.6732787349,
+    "VarianceExplained": 0.0066080768
+  },
+  "dropped_259": {
+    "CumulativeVarianceExplained": 0.5695006437,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.4488628938,
+    "VarianceExplained": 0.0065403398
+  },
+  "dropped_26": {
+    "CumulativeVarianceExplained": 0.6738807531,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.9944937187,
+    "VarianceExplained": 0.0057794847
+  },
+  "dropped_260": {
+    "CumulativeVarianceExplained": 0.5759802116,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.2465312803,
+    "VarianceExplained": 0.0064795679
+  },
+  "dropped_261": {
+    "CumulativeVarianceExplained": 0.5824521469,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.2210528604,
+    "VarianceExplained": 0.0064719353
+  },
+  "dropped_262": {
+    "CumulativeVarianceExplained": 0.5888672919,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.0310058706,
+    "VarianceExplained": 0.006415145
+  },
+  "dropped_263": {
+    "CumulativeVarianceExplained": 0.5952552724,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.9398029069,
+    "VarianceExplained": 0.0063879804
+  },
+  "dropped_264": {
+    "CumulativeVarianceExplained": 0.6016079539,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.8209993875,
+    "VarianceExplained": 0.0063526815
+  },
+  "dropped_265": {
+    "CumulativeVarianceExplained": 0.6079299251,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.7173709816,
+    "VarianceExplained": 0.0063219713
+  },
+  "dropped_266": {
+    "CumulativeVarianceExplained": 0.6142101368,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.576052972,
+    "VarianceExplained": 0.0062802116
+  },
+  "dropped_267": {
+    "CumulativeVarianceExplained": 0.620456307,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.4605061688,
+    "VarianceExplained": 0.0062461703
+  },
+  "dropped_268": {
+    "CumulativeVarianceExplained": 0.6266627783,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.3253570709,
+    "VarianceExplained": 0.0062064712
+  },
+  "dropped_269": {
+    "CumulativeVarianceExplained": 0.6327972696,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.0792059155,
+    "VarianceExplained": 0.0061344913
+  },
+  "dropped_27": {
+    "CumulativeVarianceExplained": 0.679607733,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.7759888357,
+    "VarianceExplained": 0.0057269799
+  },
+  "dropped_270": {
+    "CumulativeVarianceExplained": 0.6388767528,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.8901185168,
+    "VarianceExplained": 0.0060794832
+  },
+  "dropped_271": {
+    "CumulativeVarianceExplained": 0.6449340737,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.8136953174,
+    "VarianceExplained": 0.0060573209
+  },
+  "dropped_272": {
+    "CumulativeVarianceExplained": 0.6509720957,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.7470320699,
+    "VarianceExplained": 0.0060380221
+  },
+  "dropped_273": {
+    "CumulativeVarianceExplained": 0.6569503918,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.5400455724,
+    "VarianceExplained": 0.0059782961
+  },
+  "dropped_274": {
+    "CumulativeVarianceExplained": 0.6629073765,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.4659383217,
+    "VarianceExplained": 0.0059569846
+  },
+  "dropped_275": {
+    "CumulativeVarianceExplained": 0.6688389289,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.377328386,
+    "VarianceExplained": 0.0059315525
+  },
+  "dropped_276": {
+    "CumulativeVarianceExplained": 0.6747268983,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.2250346305,
+    "VarianceExplained": 0.0058879694
+  },
+  "dropped_277": {
+    "CumulativeVarianceExplained": 0.6805629913,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.0430246551,
+    "VarianceExplained": 0.005836093
+  },
+  "dropped_278": {
+    "CumulativeVarianceExplained": 0.6863842926,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.9909797526,
+    "VarianceExplained": 0.0058213013
+  },
+  "dropped_279": {
+    "CumulativeVarianceExplained": 0.6921449204,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.776802285,
+    "VarianceExplained": 0.0057606278
+  },
+  "dropped_28": {
+    "CumulativeVarianceExplained": 0.6852906499,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.5918412913,
+    "VarianceExplained": 0.0056829169
+  },
+  "dropped_280": {
+    "CumulativeVarianceExplained": 0.6978844085,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.7019143385,
+    "VarianceExplained": 0.0057394881
+  },
+  "dropped_281": {
+    "CumulativeVarianceExplained": 0.7035813238,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.5506800558,
+    "VarianceExplained": 0.0056969154
+  },
+  "dropped_282": {
+    "CumulativeVarianceExplained": 0.7092072884,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.2973747757,
+    "VarianceExplained": 0.0056259646
+  },
+  "dropped_283": {
+    "CumulativeVarianceExplained": 0.7148082876,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.2078649252,
+    "VarianceExplained": 0.0056009992
+  },
+  "dropped_284": {
+    "CumulativeVarianceExplained": 0.7203510092,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.9981397215,
+    "VarianceExplained": 0.0055427217
+  },
+  "dropped_285": {
+    "CumulativeVarianceExplained": 0.7258716625,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.9184338102,
+    "VarianceExplained": 0.0055206533
+  },
+  "dropped_286": {
+    "CumulativeVarianceExplained": 0.7313639402,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.8157135584,
+    "VarianceExplained": 0.0054922777
+  },
+  "dropped_287": {
+    "CumulativeVarianceExplained": 0.7367955537,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.5952131201,
+    "VarianceExplained": 0.0054316134
+  },
+  "dropped_288": {
+    "CumulativeVarianceExplained": 0.7422097492,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.531676015,
+    "VarianceExplained": 0.0054141956
+  },
+  "dropped_289": {
+    "CumulativeVarianceExplained": 0.7476012288,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.448658603,
+    "VarianceExplained": 0.0053914796
+  },
+  "dropped_29": {
+    "CumulativeVarianceExplained": 0.6909211568,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.3718781273,
+    "VarianceExplained": 0.0056305069
+  },
+  "dropped_290": {
+    "CumulativeVarianceExplained": 0.752935747,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.2397160821,
+    "VarianceExplained": 0.0053345181
+  },
+  "dropped_291": {
+    "CumulativeVarianceExplained": 0.7582512658,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.1697758477,
+    "VarianceExplained": 0.0053155188
+  },
+  "dropped_292": {
+    "CumulativeVarianceExplained": 0.7635153694,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.9798779568,
+    "VarianceExplained": 0.0052641037
+  },
+  "dropped_293": {
+    "CumulativeVarianceExplained": 0.768739832,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.8328325677,
+    "VarianceExplained": 0.0052244626
+  },
+  "dropped_294": {
+    "CumulativeVarianceExplained": 0.7739351864,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.7245022205,
+    "VarianceExplained": 0.0051953543
+  },
+  "dropped_295": {
+    "CumulativeVarianceExplained": 0.7790852897,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.5554901877,
+    "VarianceExplained": 0.0051501033
+  },
+  "dropped_296": {
+    "CumulativeVarianceExplained": 0.7842004369,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.424420465,
+    "VarianceExplained": 0.0051151472
+  },
+  "dropped_297": {
+    "CumulativeVarianceExplained": 0.7892456235,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.1607477253,
+    "VarianceExplained": 0.0050451866
+  },
+  "dropped_298": {
+    "CumulativeVarianceExplained": 0.7942867296,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.1453123874,
+    "VarianceExplained": 0.0050411061
+  },
+  "dropped_299": {
+    "CumulativeVarianceExplained": 0.7992810832,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.968015709,
+    "VarianceExplained": 0.0049943536
+  },
+  "dropped_3": {
+    "CumulativeVarianceExplained": 0.5328153875,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 51.1502769237,
+    "VarianceExplained": 0.0065645093
+  },
+  "dropped_30": {
+    "CumulativeVarianceExplained": 0.6965335422,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.2955847384,
+    "VarianceExplained": 0.0056123854
+  },
+  "dropped_300": {
+    "CumulativeVarianceExplained": 0.804262201,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.9176719843,
+    "VarianceExplained": 0.0049811178
+  },
+  "dropped_301": {
+    "CumulativeVarianceExplained": 0.8092076402,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.7816300518,
+    "VarianceExplained": 0.0049454392
+  },
+  "dropped_302": {
+    "CumulativeVarianceExplained": 0.8141262095,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.678851634,
+    "VarianceExplained": 0.0049185694
+  },
+  "dropped_303": {
+    "CumulativeVarianceExplained": 0.8190342537,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.6385157397,
+    "VarianceExplained": 0.0049080442
+  },
+  "dropped_304": {
+    "CumulativeVarianceExplained": 0.8238917258,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.4441017943,
+    "VarianceExplained": 0.0048574721
+  },
+  "dropped_305": {
+    "CumulativeVarianceExplained": 0.8287158423,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.3153180388,
+    "VarianceExplained": 0.0048241164
+  },
+  "dropped_306": {
+    "CumulativeVarianceExplained": 0.8334775403,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.0731241964,
+    "VarianceExplained": 0.0047616981
+  },
+  "dropped_307": {
+    "CumulativeVarianceExplained": 0.8381889629,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.8768898217,
+    "VarianceExplained": 0.0047114225
+  },
+  "dropped_308": {
+    "CumulativeVarianceExplained": 0.8428756624,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.7800075495,
+    "VarianceExplained": 0.0046866995
+  },
+  "dropped_309": {
+    "CumulativeVarianceExplained": 0.847543594,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.706290441,
+    "VarianceExplained": 0.0046679315
+  },
+  "dropped_31": {
+    "CumulativeVarianceExplained": 0.7021252759,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.2084885412,
+    "VarianceExplained": 0.0055917337
+  },
+  "dropped_310": {
+    "CumulativeVarianceExplained": 0.8521933266,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.6346671144,
+    "VarianceExplained": 0.0046497327
+  },
+  "dropped_311": {
+    "CumulativeVarianceExplained": 0.8568133143,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.5173006427,
+    "VarianceExplained": 0.0046199877
+  },
+  "dropped_312": {
+    "CumulativeVarianceExplained": 0.8613660311,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.2504643799,
+    "VarianceExplained": 0.0045527168
+  },
+  "dropped_313": {
+    "CumulativeVarianceExplained": 0.8658637571,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.0308704784,
+    "VarianceExplained": 0.004497726
+  },
+  "dropped_314": {
+    "CumulativeVarianceExplained": 0.8703255635,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.8867080411,
+    "VarianceExplained": 0.0044618065
+  },
+  "dropped_315": {
+    "CumulativeVarianceExplained": 0.8747653595,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.7980824759,
+    "VarianceExplained": 0.004439796
+  },
+  "dropped_316": {
+    "CumulativeVarianceExplained": 0.8791515946,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.5814964895,
+    "VarianceExplained": 0.0043862351
+  },
+  "dropped_317": {
+    "CumulativeVarianceExplained": 0.8835077634,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.4593368358,
+    "VarianceExplained": 0.0043561688
+  },
+  "dropped_318": {
+    "CumulativeVarianceExplained": 0.8878127127,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.2502565068,
+    "VarianceExplained": 0.0043049494
+  },
+  "dropped_319": {
+    "CumulativeVarianceExplained": 0.89210293,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.1898893584,
+    "VarianceExplained": 0.0042902173
+  },
+  "dropped_32": {
+    "CumulativeVarianceExplained": 0.7076780473,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 47.0437302312,
+    "VarianceExplained": 0.0055527714
+  },
+  "dropped_320": {
+    "CumulativeVarianceExplained": 0.8963546451,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 35.0316292453,
+    "VarianceExplained": 0.0042517151
+  },
+  "dropped_321": {
+    "CumulativeVarianceExplained": 0.9005568013,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.8268627829,
+    "VarianceExplained": 0.0042021562
+  },
+  "dropped_322": {
+    "CumulativeVarianceExplained": 0.9047384645,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.7418373178,
+    "VarianceExplained": 0.0041816632
+  },
+  "dropped_323": {
+    "CumulativeVarianceExplained": 0.9088995596,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.6562907642,
+    "VarianceExplained": 0.0041610951
+  },
+  "dropped_324": {
+    "CumulativeVarianceExplained": 0.9130453305,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.5924167742,
+    "VarianceExplained": 0.0041457709
+  },
+  "dropped_325": {
+    "CumulativeVarianceExplained": 0.917129661,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.3351302032,
+    "VarianceExplained": 0.0040843305
+  },
+  "dropped_326": {
+    "CumulativeVarianceExplained": 0.9211493721,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 34.0624341227,
+    "VarianceExplained": 0.0040197111
+  },
+  "dropped_327": {
+    "CumulativeVarianceExplained": 0.9251272262,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.8846248398,
+    "VarianceExplained": 0.0039778541
+  },
+  "dropped_328": {
+    "CumulativeVarianceExplained": 0.9290630354,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.7050734237,
+    "VarianceExplained": 0.0039358092
+  },
+  "dropped_329": {
+    "CumulativeVarianceExplained": 0.9329959893,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.692844919,
+    "VarianceExplained": 0.0039329538
+  },
+  "dropped_33": {
+    "CumulativeVarianceExplained": 0.7131849615,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.8490737734,
+    "VarianceExplained": 0.0055069142
+  },
+  "dropped_330": {
+    "CumulativeVarianceExplained": 0.936882365,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.4927378174,
+    "VarianceExplained": 0.0038863757
+  },
+  "dropped_331": {
+    "CumulativeVarianceExplained": 0.9407316362,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.332471504,
+    "VarianceExplained": 0.0038492713
+  },
+  "dropped_332": {
+    "CumulativeVarianceExplained": 0.9445415097,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.1614516995,
+    "VarianceExplained": 0.0038098735
+  },
+  "dropped_333": {
+    "CumulativeVarianceExplained": 0.9483229688,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 33.0375597738,
+    "VarianceExplained": 0.0037814591
+  },
+  "dropped_334": {
+    "CumulativeVarianceExplained": 0.9520869129,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.960959044,
+    "VarianceExplained": 0.0037639441
+  },
+  "dropped_335": {
+    "CumulativeVarianceExplained": 0.9557830699,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.6628039855,
+    "VarianceExplained": 0.003696157
+  },
+  "dropped_336": {
+    "CumulativeVarianceExplained": 0.959456827,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.563679782,
+    "VarianceExplained": 0.0036737571
+  },
+  "dropped_337": {
+    "CumulativeVarianceExplained": 0.9631289777,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.5565598206,
+    "VarianceExplained": 0.0036721507
+  },
+  "dropped_338": {
+    "CumulativeVarianceExplained": 0.9667312145,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.2451487407,
+    "VarianceExplained": 0.0036022368
+  },
+  "dropped_339": {
+    "CumulativeVarianceExplained": 0.9702963567,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 32.0786947751,
+    "VarianceExplained": 0.0035651422
+  },
+  "dropped_34": {
+    "CumulativeVarianceExplained": 0.7186598137,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.7124943317,
+    "VarianceExplained": 0.0054748523
+  },
+  "dropped_340": {
+    "CumulativeVarianceExplained": 0.9738342366,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 31.955807699,
+    "VarianceExplained": 0.0035378799
+  },
+  "dropped_341": {
+    "CumulativeVarianceExplained": 0.9772837891,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 31.5543789728,
+    "VarianceExplained": 0.0034495525
+  },
+  "dropped_342": {
+    "CumulativeVarianceExplained": 0.9807010007,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 31.4061134331,
+    "VarianceExplained": 0.0034172116
+  },
+  "dropped_343": {
+    "CumulativeVarianceExplained": 0.984024511,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.9725361689,
+    "VarianceExplained": 0.0033235102
+  },
+  "dropped_344": {
+    "CumulativeVarianceExplained": 0.9873321434,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.8984632909,
+    "VarianceExplained": 0.0033076325
+  },
+  "dropped_345": {
+    "CumulativeVarianceExplained": 0.9906158549,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.786530999,
+    "VarianceExplained": 0.0032837115
+  },
+  "dropped_346": {
+    "CumulativeVarianceExplained": 0.9937997939,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 30.315212928,
+    "VarianceExplained": 0.0031839389
+  },
+  "dropped_347": {
+    "CumulativeVarianceExplained": 0.9969081336,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 29.953149742,
+    "VarianceExplained": 0.0031083397
+  },
+  "dropped_348": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 29.8736726058,
+    "VarianceExplained": 0.0030918664
+  },
+  "dropped_349": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_35": {
+    "CumulativeVarianceExplained": 0.7241160982,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.6332148957,
+    "VarianceExplained": 0.0054562845
+  },
+  "dropped_350": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_351": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_352": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_353": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "WM",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_36": {
+    "CumulativeVarianceExplained": 0.7295392778,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.4915308769,
+    "VarianceExplained": 0.0054231796
+  },
+  "dropped_37": {
+    "CumulativeVarianceExplained": 0.7349475331,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.4275160651,
+    "VarianceExplained": 0.0054082553
+  },
+  "dropped_38": {
+    "CumulativeVarianceExplained": 0.7403262869,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.300714166,
+    "VarianceExplained": 0.0053787538
+  },
+  "dropped_39": {
+    "CumulativeVarianceExplained": 0.7456698402,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.1489607698,
+    "VarianceExplained": 0.0053435532
+  },
+  "dropped_4": {
+    "CumulativeVarianceExplained": 0.5393320399,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.9634865751,
+    "VarianceExplained": 0.0065166524
+  },
+  "dropped_40": {
+    "CumulativeVarianceExplained": 0.7509825931,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 46.0157667806,
+    "VarianceExplained": 0.0053127529
+  },
+  "dropped_41": {
+    "CumulativeVarianceExplained": 0.7562683261,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.8986028443,
+    "VarianceExplained": 0.005285733
+  },
+  "dropped_42": {
+    "CumulativeVarianceExplained": 0.7614953872,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.6431539607,
+    "VarianceExplained": 0.0052270612
+  },
+  "dropped_43": {
+    "CumulativeVarianceExplained": 0.7666897674,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.5002435705,
+    "VarianceExplained": 0.0051943802
+  },
+  "dropped_44": {
+    "CumulativeVarianceExplained": 0.7718433509,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.3212115377,
+    "VarianceExplained": 0.0051535834
+  },
+  "dropped_45": {
+    "CumulativeVarianceExplained": 0.7769884752,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.2840012851,
+    "VarianceExplained": 0.0051451244
+  },
+  "dropped_46": {
+    "CumulativeVarianceExplained": 0.7821216262,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.2312793496,
+    "VarianceExplained": 0.0051331509
+  },
+  "dropped_47": {
+    "CumulativeVarianceExplained": 0.7872107864,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 45.0370482153,
+    "VarianceExplained": 0.0050891603
+  },
+  "dropped_48": {
+    "CumulativeVarianceExplained": 0.7922861306,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.9758733243,
+    "VarianceExplained": 0.0050753442
+  },
+  "dropped_49": {
+    "CumulativeVarianceExplained": 0.7973277162,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.8260455135,
+    "VarianceExplained": 0.0050415856
+  },
+  "dropped_5": {
+    "CumulativeVarianceExplained": 0.5458087681,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.8071335543,
+    "VarianceExplained": 0.0064767283
+  },
+  "dropped_50": {
+    "CumulativeVarianceExplained": 0.8023289768,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.646415513,
+    "VarianceExplained": 0.0050012606
+  },
+  "dropped_51": {
+    "CumulativeVarianceExplained": 0.8072778205,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.4118357512,
+    "VarianceExplained": 0.0049488437
+  },
+  "dropped_52": {
+    "CumulativeVarianceExplained": 0.812193694,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.2636480817,
+    "VarianceExplained": 0.0049158735
+  },
+  "dropped_53": {
+    "CumulativeVarianceExplained": 0.8170578946,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.030396237,
+    "VarianceExplained": 0.0048642006
+  },
+  "dropped_54": {
+    "CumulativeVarianceExplained": 0.8219184787,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 44.0140248149,
+    "VarianceExplained": 0.0048605841
+  },
+  "dropped_55": {
+    "CumulativeVarianceExplained": 0.8267434775,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.8526113776,
+    "VarianceExplained": 0.0048249988
+  },
+  "dropped_56": {
+    "CumulativeVarianceExplained": 0.8315482156,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.7604437921,
+    "VarianceExplained": 0.0048047382
+  },
+  "dropped_57": {
+    "CumulativeVarianceExplained": 0.8362905324,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.4752546691,
+    "VarianceExplained": 0.0047423168
+  },
+  "dropped_58": {
+    "CumulativeVarianceExplained": 0.8410213478,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.4225034018,
+    "VarianceExplained": 0.0047308154
+  },
+  "dropped_59": {
+    "CumulativeVarianceExplained": 0.8457110448,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.2333856121,
+    "VarianceExplained": 0.004689697
+  },
+  "dropped_6": {
+    "CumulativeVarianceExplained": 0.5522362598,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.6136452854,
+    "VarianceExplained": 0.0064274917
+  },
+  "dropped_60": {
+    "CumulativeVarianceExplained": 0.8503810084,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 43.1423305587,
+    "VarianceExplained": 0.0046699636
+  },
+  "dropped_61": {
+    "CumulativeVarianceExplained": 0.8550168139,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.9842603333,
+    "VarianceExplained": 0.0046358055
+  },
+  "dropped_62": {
+    "CumulativeVarianceExplained": 0.859624781,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.8550038778,
+    "VarianceExplained": 0.0046079671
+  },
+  "dropped_63": {
+    "CumulativeVarianceExplained": 0.8641895197,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.6535139631,
+    "VarianceExplained": 0.0045647387
+  },
+  "dropped_64": {
+    "CumulativeVarianceExplained": 0.8687425742,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.5988899243,
+    "VarianceExplained": 0.0045530546
+  },
+  "dropped_65": {
+    "CumulativeVarianceExplained": 0.8732636985,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.4492553232,
+    "VarianceExplained": 0.0045211242
+  },
+  "dropped_66": {
+    "CumulativeVarianceExplained": 0.8777614288,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.3392890508,
+    "VarianceExplained": 0.0044977303
+  },
+  "dropped_67": {
+    "CumulativeVarianceExplained": 0.882199259,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.0564098193,
+    "VarianceExplained": 0.0044378302
+  },
+  "dropped_68": {
+    "CumulativeVarianceExplained": 0.8866307256,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 42.0262456307,
+    "VarianceExplained": 0.0044314666
+  },
+  "dropped_69": {
+    "CumulativeVarianceExplained": 0.8910253067,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.8509765177,
+    "VarianceExplained": 0.0043945811
+  },
+  "dropped_7": {
+    "CumulativeVarianceExplained": 0.558640543,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.5221840446,
+    "VarianceExplained": 0.0064042831
+  },
+  "dropped_70": {
+    "CumulativeVarianceExplained": 0.8953893779,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.7054460096,
+    "VarianceExplained": 0.0043640712
+  },
+  "dropped_71": {
+    "CumulativeVarianceExplained": 0.8997005159,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.4517451513,
+    "VarianceExplained": 0.004311138
+  },
+  "dropped_72": {
+    "CumulativeVarianceExplained": 0.9039967968,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.3802575939,
+    "VarianceExplained": 0.0042962809
+  },
+  "dropped_73": {
+    "CumulativeVarianceExplained": 0.9082471668,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 41.1585648802,
+    "VarianceExplained": 0.00425037
+  },
+  "dropped_74": {
+    "CumulativeVarianceExplained": 0.9124566638,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.960189507,
+    "VarianceExplained": 0.004209497
+  },
+  "dropped_75": {
+    "CumulativeVarianceExplained": 0.916629683,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.7823312357,
+    "VarianceExplained": 0.0041730192
+  },
+  "dropped_76": {
+    "CumulativeVarianceExplained": 0.9207709037,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.6266526285,
+    "VarianceExplained": 0.0041412207
+  },
+  "dropped_77": {
+    "CumulativeVarianceExplained": 0.9248852327,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.4945299566,
+    "VarianceExplained": 0.004114329
+  },
+  "dropped_78": {
+    "CumulativeVarianceExplained": 0.9289945679,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.4699473747,
+    "VarianceExplained": 0.0041093352
+  },
+  "dropped_79": {
+    "CumulativeVarianceExplained": 0.9330708735,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.3069764421,
+    "VarianceExplained": 0.0040763056
+  },
+  "dropped_8": {
+    "CumulativeVarianceExplained": 0.5649913256,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.3107139846,
+    "VarianceExplained": 0.0063507827
+  },
+  "dropped_80": {
+    "CumulativeVarianceExplained": 0.9371053254,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.0995156722,
+    "VarianceExplained": 0.0040344519
+  },
+  "dropped_81": {
+    "CumulativeVarianceExplained": 0.9411210657,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 40.006418007,
+    "VarianceExplained": 0.0040157404
+  },
+  "dropped_82": {
+    "CumulativeVarianceExplained": 0.9450742097,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.6933879117,
+    "VarianceExplained": 0.0039531439
+  },
+  "dropped_83": {
+    "CumulativeVarianceExplained": 0.9489991237,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.5514063574,
+    "VarianceExplained": 0.0039249141
+  },
+  "dropped_84": {
+    "CumulativeVarianceExplained": 0.9528691135,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.2736948768,
+    "VarianceExplained": 0.0038699897
+  },
+  "dropped_85": {
+    "CumulativeVarianceExplained": 0.9567172064,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 39.1624300982,
+    "VarianceExplained": 0.003848093
+  },
+  "dropped_86": {
+    "CumulativeVarianceExplained": 0.9605135913,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.8984209327,
+    "VarianceExplained": 0.0037963849
+  },
+  "dropped_87": {
+    "CumulativeVarianceExplained": 0.9642960511,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.8270163748,
+    "VarianceExplained": 0.0037824599
+  },
+  "dropped_88": {
+    "CumulativeVarianceExplained": 0.9680717393,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.7922449726,
+    "VarianceExplained": 0.0037756882
+  },
+  "dropped_89": {
+    "CumulativeVarianceExplained": 0.9718029263,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.5629602145,
+    "VarianceExplained": 0.003731187
+  },
+  "dropped_9": {
+    "CumulativeVarianceExplained": 0.5713229525,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 50.2347806408,
+    "VarianceExplained": 0.0063316268
+  },
+  "dropped_90": {
+    "CumulativeVarianceExplained": 0.9755119587,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.4483020369,
+    "VarianceExplained": 0.0037090323
+  },
+  "dropped_91": {
+    "CumulativeVarianceExplained": 0.9791899692,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.2871762124,
+    "VarianceExplained": 0.0036780105
+  },
+  "dropped_92": {
+    "CumulativeVarianceExplained": 0.9828163673,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 38.0175914647,
+    "VarianceExplained": 0.0036263982
+  },
+  "dropped_93": {
+    "CumulativeVarianceExplained": 0.98634219,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.4866891234,
+    "VarianceExplained": 0.0035258226
+  },
+  "dropped_94": {
+    "CumulativeVarianceExplained": 0.98983276,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.2988148346,
+    "VarianceExplained": 0.00349057
+  },
+  "dropped_95": {
+    "CumulativeVarianceExplained": 0.9932755143,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 37.0424644503,
+    "VarianceExplained": 0.0034427543
+  },
+  "dropped_96": {
+    "CumulativeVarianceExplained": 0.9966809025,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.8408947534,
+    "VarianceExplained": 0.0034053882
+  },
+  "dropped_97": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 36.3711353187,
+    "VarianceExplained": 0.0033190975
+  },
+  "dropped_98": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "dropped_99": {
+    "CumulativeVarianceExplained": 1.0,
+    "Mask": "combined",
+    "Method": "aCompCor",
+    "Retained": false,
+    "SingularValue": 0.0,
+    "VarianceExplained": 0.0
+  },
+  "t_comp_cor_00": {
+    "CumulativeVarianceExplained": 0.1350190434,
+    "Method": "tCompCor",
+    "Retained": true,
+    "SingularValue": 99.5781027324,
+    "VarianceExplained": 0.1350190434
+  },
+  "t_comp_cor_01": {
+    "CumulativeVarianceExplained": 0.2555278833,
+    "Method": "tCompCor",
+    "Retained": true,
+    "SingularValue": 94.0753379362,
+    "VarianceExplained": 0.12050884
+  },
+  "t_comp_cor_02": {
+    "CumulativeVarianceExplained": 0.3606637478,
+    "Method": "tCompCor",
+    "Retained": true,
+    "SingularValue": 87.8702332193,
+    "VarianceExplained": 0.1051358645
+  },
+  "t_comp_cor_03": {
+    "CumulativeVarianceExplained": 0.4381768952,
+    "Method": "tCompCor",
+    "Retained": true,
+    "SingularValue": 75.4490924027,
+    "VarianceExplained": 0.0775131474
+  },
+  "t_comp_cor_04": {
+    "CumulativeVarianceExplained": 0.4807485979,
+    "Method": "tCompCor",
+    "Retained": true,
+    "SingularValue": 55.9148088376,
+    "VarianceExplained": 0.0425717027
+  },
+  "t_comp_cor_05": {
+    "CumulativeVarianceExplained": 0.5196386638,
+    "Method": "tCompCor",
+    "Retained": true,
+    "SingularValue": 53.4423655921,
+    "VarianceExplained": 0.0388900659
+  }
+}

--- a/load_confounds/parser.py
+++ b/load_confounds/parser.py
@@ -114,15 +114,19 @@ def _label_compcor(confounds_json, prefix, n_compcor, compcor_mask):
     return _select_compcor(compcor_cols, n_compcor, compcor_mask)
 
 
+def _load_acompcor(confounds_json, n_compcor, acompcor_combined):
+    if acompcor_combined:
+        compcor_cols = _label_compcor(confounds_json, "a", n_compcor, "combined")
+    else:
+        compcor_cols = _label_compcor(confounds_json, "a", n_compcor, "WM")
+        compcor_cols.extend(_label_compcor(confounds_json, "a", n_compcor, "CSF"))
+    return compcor_cols
+
 def _load_compcor(confounds_raw, confounds_json, compcor, n_compcor, acompcor_combined):
     """Load compcor regressors."""
     if compcor == "anat":
-        if acompcor_combined:
-            compcor_cols = _label_compcor(confounds_json, "a", n_compcor, "combined")
-        else:
-            compcor_cols = _label_compcor(confounds_json, "a", n_compcor, "WM")
-            compcor_cols.extend(_label_compcor(confounds_json, "a", n_compcor, "CSF"))
-
+        compcor_cols = _load_acompcor(confounds_json, n_compcor, acompcor_combined)
+        
     if compcor == "temp":
         compcor_cols = _label_compcor(confounds_json, "t", n_compcor, acompcor_combined)
 

--- a/load_confounds/parser.py
+++ b/load_confounds/parser.py
@@ -90,7 +90,7 @@ def _select_compcor(compcor_cols, n_compcor, compcor_mask):
     """retain a specified number of compcor components."""
     # only select if not "auto", or less components are requested than there actually is
     if (n_compcor != "auto") and (n_compcor < len(compcor_cols)):
-        compcor_cols = compcor_col[0:n_compcor]
+        compcor_cols = compcor_cols[0:n_compcor]
     return compcor_cols
 
 
@@ -126,7 +126,7 @@ def _load_compcor(confounds_raw, confounds_json, compcor, n_compcor, acompcor_co
     """Load compcor regressors."""
     if compcor == "anat":
         compcor_cols = _load_acompcor(confounds_json, n_compcor, acompcor_combined)
-        
+
     if compcor == "temp":
         compcor_cols = _label_compcor(confounds_json, "t", n_compcor, acompcor_combined)
 

--- a/load_confounds/parser.py
+++ b/load_confounds/parser.py
@@ -76,8 +76,8 @@ def _load_high_pass(confounds_raw):
     high_pass_params = _find_confounds(confounds_raw, ["cosine"])
     return confounds_raw[high_pass_params]
 
-  
-def _select_compcor(confounds_json, compcor_suffic, n_compcor, acompcor_mask, compcor_cols):
+
+def _select_compcor(confounds_json, compcor_suffix, n_compcor, acompcor_mask, compcor_cols):
     """Selects the first given number of compcor components (n_compcor)"""
     # Only limit if the number of components is specified (otherwise, collect all compcor components)
     if n_compcor != None:
@@ -91,9 +91,9 @@ def _select_compcor(confounds_json, compcor_suffic, n_compcor, acompcor_mask, co
             wm_comps = [comp for comp in compcor_cols if confounds_json[comp]['Mask']=='WM']
             compcor_cols = csf_comps[0:n_compcor] + wm_comps[0:n_compcor]
         else: compcor_cols = compcor_cols[0:n_compcor]
-    return compcor_cols    
+    return compcor_cols
 
-  
+
 def _label_compcor(confounds_json, compcor_suffix, n_compcor, acompcor_mask):
     """Builds list for the number of compcor components."""
     compcor_cols = [key for key in confounds_json.keys() if compcor_suffix+'_comp' in key]
@@ -105,7 +105,7 @@ def _label_compcor(confounds_json, compcor_suffix, n_compcor, acompcor_mask):
     compcor_cols = _select_compcor(confounds_json, compcor_suffic, n_compcor, acompcor_mask, compcor_cols)
     return compcor_cols
 
-  
+
 def _load_compcor(confounds_raw, confounds_json, compcor, n_compcor, acompcor_mask):
     """Load compcor regressors."""
     if compcor == "anat":
@@ -136,13 +136,13 @@ def _load_motion(confounds_raw, motion, n_motion):
 
     return confounds_motion
 
-  
+
 def _load_ica_aroma(confounds_raw):
     """Load the ICA-AROMA regressors."""
     ica_aroma_params = _find_confounds(confounds_raw, ["aroma"])
     return confounds_raw[ica_aroma_params]
 
-  
+
 def _pca_motion(confounds_motion, n_components):
     """Reduce the motion paramaters using PCA."""
     n_available = confounds_motion.shape[1]
@@ -159,7 +159,7 @@ def _pca_motion(confounds_motion, n_components):
     motion_pca.columns = ["motion_pca_" + str(col + 1) for col in motion_pca.columns]
     return motion_pca
 
-  
+
 def _load_censoring(confounds_raw, censoring, fd_thresh, std_dvars_thresh):
     """Perform basic censoring - Remove volumes if framewise displacement exceeds threshold"""
     """Power, Jonathan D., et al. "Steps toward optimizing motion artifact removal in functional connectivity MRI; a reply to Carp." Neuroimage 76 (2013)."""
@@ -177,16 +177,16 @@ def _load_censoring(confounds_raw, censoring, fd_thresh, std_dvars_thresh):
     motion_outlier_regressors.columns=column_names
     return motion_outlier_regressors
 
-  
+
 def _optimize_censoring(fd_outliers, n_scans):
     """Perform optimized censoring. After censoring volumes, further remove continuous segments containing fewer than 5 volumes"""
     """Power, Jonathan D., et al. "Methods to detect, characterize, and remove motion artifact in resting state fMRI." Neuroimage 84 (2014): 320-341."""
     # Start by checking if the beginning continuous segment is fewer than 5 volumes
     if fd_outliers[0] < 5:
         fd_outliers = np.asarray(list(range(fd_outliers[0])) + list(fd_outliers))
-    # Do the same for the ending segment of scans  
+    # Do the same for the ending segment of scans
     if n_scans - (fd_outliers[-1] + 1) < 5:
-        fd_outliers = np.asarray(list(fd_outliers) + list(range(fd_outliers[-1], n_scans)))   
+        fd_outliers = np.asarray(list(fd_outliers) + list(range(fd_outliers[-1], n_scans)))
     # Now do everything in between
     fd_outlier_ind_diffs = np.diff(fd_outliers)
     short_segments_inds = np.where(np.logical_and(fd_outlier_ind_diffs > 1, fd_outlier_ind_diffs < 6))[0]
@@ -195,7 +195,7 @@ def _optimize_censoring(fd_outliers, n_scans):
     fd_outliers = np.sort(np.unique(fd_outliers))
     return fd_outliers
 
-  
+
 def _sanitize_strategy(strategy):
     """Defines the supported denoising strategies."""
     if isinstance(strategy, list):
@@ -286,10 +286,10 @@ class Confounds:
         analysis is applied to the motion parameters, and the number of extracted
         components is set to exceed `n_motion` percent of the parameters variance.
         If the n_components = 0, then no PCA is performed.
-        
+
     fd_thresh : float, optional
         Framewise displacement threshold for censoring (default = 0.2 mm)
-        
+
     std_dvars_thresh : float, optional
         Standardized DVARS threshold for censoring (default = 3)
 
@@ -415,7 +415,7 @@ class Confounds:
               confounds_json = json.load(f)
         # Convert tsv file to pandas dataframe
         confounds_raw = _confounds_to_df(confounds_raw)
-        
+
         confounds = pd.DataFrame()
 
         if "motion" in self.strategy:
@@ -425,7 +425,7 @@ class Confounds:
         if "censoring" in self.strategy:
             confounds_censoring = _load_censoring(confounds_raw, self.censoring, self.fd_thresh, self.std_dvars_thresh)
             confounds = pd.concat([confounds, confounds_censoring], axis=1)
-            
+
         if "high_pass" in self.strategy:
             confounds_high_pass = _load_high_pass(confounds_raw)
             confounds = pd.concat([confounds, confounds_high_pass], axis=1)

--- a/load_confounds/strategies.py
+++ b/load_confounds/strategies.py
@@ -176,11 +176,11 @@ class AnatCompCor(Confounds):
     confounds_raw : Pandas Dataframe or path to tsv file(s), optionally as a list.
         Raw confounds from fmriprep
 
-    n_compcor : int, optional
+    n_compcor : int or "auto", optional
         The number of noise components to be extracted.
-        Default is to select all components (50% variance explained by fMRIPrep defaults)
+        Default is "auto": select all components (50% variance explained by fMRIPrep defaults)
 
-    acompcor_combine: boolean, optional
+    acompcor_combined: boolean, optional
         If true, use components generated from the combined white matter and csf
         masks. Otherwise, components are generated from each mask separately and then
         concatenated.
@@ -198,14 +198,14 @@ class AnatCompCor(Confounds):
 
     """
 
-    def __init__(self, n_compcor=10, demean=True):
+    def __init__(self, n_compcor="auto", demean=True, acompcor_combined=True):
         """Default parameters."""
         self.strategy = ["high_pass", "motion", "compcor"]
         self.motion = "full"
         self.n_motion = 0
         self.compcor = "anat"
         self.n_compcor = n_compcor
-        self.acompcor_combine = True
+        self.acompcor_combined = acompcor_combined
         self.demean = demean
 
 
@@ -219,9 +219,9 @@ class TempCompCor(Confounds):
     confounds_raw : Pandas Dataframe or path to tsv file(s), optionally as a list.
         Raw confounds from fmriprep
 
-    n_compcor : int, optional
+    n_compcor : int or "auto", optional
         The number of noise components to be extracted.
-        Default is to select all components (50% variance explained by fMRIPrep defaults)
+        Default is "auto": select all components (50% variance explained by fMRIPrep defaults)
 
     demean : boolean, optional
         If True, the confounds are standardized to a zero mean (over time).
@@ -236,12 +236,12 @@ class TempCompCor(Confounds):
 
     """
 
-    def __init__(self, n_compcor=6, demean=True):
+    def __init__(self, n_compcor="auto", demean=True):
         """Default parameters."""
         self.strategy = ["high_pass", "compcor"]
         self.compcor = "temp"
         self.n_compcor = n_compcor
-        self.acompcor_combine = None
+        self.acompcor_combined = None
         self.demean = demean
 
 
@@ -277,6 +277,7 @@ class ICAAROMA(Confounds):
         self.demean = demean
         self.wm_csf = "basic"
 
+
 class AROMAGSR(Confounds):
     """
     Load confounds for post-non-aggresive AROMA-GSR strategy from Ciric et al. 2017.
@@ -309,6 +310,7 @@ class AROMAGSR(Confounds):
         self.global_signal = "basic"
         self.wm_csf = "basic"
         self.demean = demean
+
 
 class AggrICAAROMA(Confounds):
     """

--- a/load_confounds/strategies.py
+++ b/load_confounds/strategies.py
@@ -178,6 +178,12 @@ class AnatCompCor(Confounds):
 
     n_compcor : int, optional
         The number of noise components to be extracted.
+        Default is to select all components (50% variance explained by fMRIPrep defaults)
+
+    acompcor_combine: boolean, optional
+        If true, use components generated from the combined white matter and csf
+        masks. Otherwise, components are generated from each mask separately and then
+        concatenated.
 
     demean : boolean, optional
         If True, the confounds are standardized to a zero mean (over time).
@@ -199,6 +205,7 @@ class AnatCompCor(Confounds):
         self.n_motion = 0
         self.compcor = "anat"
         self.n_compcor = n_compcor
+        self.acompcor_combine = True
         self.demean = demean
 
 
@@ -214,6 +221,7 @@ class TempCompCor(Confounds):
 
     n_compcor : int, optional
         The number of noise components to be extracted.
+        Default is to select all components (50% variance explained by fMRIPrep defaults)
 
     demean : boolean, optional
         If True, the confounds are standardized to a zero mean (over time).
@@ -233,6 +241,7 @@ class TempCompCor(Confounds):
         self.strategy = ["high_pass", "compcor"]
         self.compcor = "temp"
         self.n_compcor = n_compcor
+        self.acompcor_combine = None
         self.demean = demean
 
 

--- a/load_confounds/tests/test_parser.py
+++ b/load_confounds/tests/test_parser.py
@@ -247,6 +247,15 @@ def test_motion():
         assert f"{param}_derivative1_power2" in conf_full.columns_
 
 
+def test_n_compcor():
+
+    conf = lc.Confounds(strategy=["compcor"], compcor="anat", n_compcor=2)
+    conf.load(file_confounds)
+    assert "a_comp_cor_00" in conf.columns_
+    assert "a_comp_cor_01" in conf.columns_
+    assert "a_comp_cor_02" not in conf.columns_
+
+
 def test_n_motion():
 
     conf = lc.Confounds(strategy=["motion"], motion="full", n_motion=0.2)

--- a/load_confounds/tests/test_parser.py
+++ b/load_confounds/tests/test_parser.py
@@ -13,6 +13,7 @@ from nilearn.input_data import NiftiMasker
 path_data = os.path.join(os.path.dirname(lc.__file__), "data")
 file_confounds = os.path.join(path_data, "test_desc-confounds_regressors.tsv")
 
+
 def _simu_img(demean=True):
     """Simulate an nifti image based on confound file with some parts confounds and some parts noise."""
     # set the size of the image matrix
@@ -65,6 +66,7 @@ def _tseries_std(img, mask_img, confounds, standardize):
     tseries = masker.fit_transform(img, confounds=confounds)
     return tseries.std(axis=0)
 
+
 def _denoise(img, mask_img, confounds, standardize):
     """Extract time series with and without confounds."""
     masker = NiftiMasker(mask_img=mask_img, standardize=standardize)
@@ -91,6 +93,7 @@ def _regression(confounds):
     masker = NiftiMasker(mask_img=mask_conf, standardize=True)
     tseries_clean = masker.fit_transform(img, confounds)
     assert tseries_clean.shape[0] == confounds.shape[0]
+
 
 @pytest.mark.filterwarnings("ignore")
 def test_nilearn_regress():
@@ -124,6 +127,7 @@ def test_nilearn_regress():
     confounds = lc.Confounds(strategy=["ica_aroma"]).load(file_confounds)
     _regression(confounds)
 
+
 @pytest.mark.filterwarnings("ignore")
 def test_nilearn_standardize_false():
     """Test removing confounds in nilearn with no standardization."""
@@ -139,6 +143,7 @@ def test_nilearn_standardize_false():
     # in voxels composed of random noise
     tseries_std = _tseries_std(img, mask_rand, X, False)
     assert np.mean(tseries_std > 0.9)
+
 
 @pytest.mark.filterwarnings("ignore")
 def test_nilearn_standardize_zscore():
@@ -162,6 +167,7 @@ def test_nilearn_standardize_zscore():
     tseries_raw, tseries_clean = _denoise(img, mask_rand, X, "zscore")
     corr = _corr_tseries(tseries_raw, tseries_clean)
     assert corr.mean() > 0.8
+
 
 def test_nilearn_standardize_psc():
     """Test removing confounds in nilearn with psc standardization."""
@@ -240,6 +246,7 @@ def test_motion():
         assert f"{param}_power2" in conf_full.columns_
         assert f"{param}_derivative1_power2" in conf_full.columns_
 
+
 def test_n_motion():
 
     conf = lc.Confounds(strategy=["motion"], motion="full", n_motion=0.2)
@@ -255,8 +262,9 @@ def test_n_motion():
         conf = lc.Confounds(strategy=["motion"], motion="full", n_motion=50)
         conf.load(file_confounds)
 
+
 def test_ica_aroma():
     conf = lc.Confounds(strategy=["ica_aroma"])
     conf.load(file_confounds)
     for col_name in conf.columns_:
-        assert re.match('aroma_motion_+', col_name)
+        assert re.match("aroma_motion_+", col_name)

--- a/load_confounds/tests/test_parser.py
+++ b/load_confounds/tests/test_parser.py
@@ -181,18 +181,6 @@ def test_nilearn_standardize_psc():
     assert corr.mean() > 0.8
 
 
-def test_read_file():
-    """Check that loading missing or incomplete files produce error messages."""
-    conf = lc.Confounds()
-    with pytest.raises(FileNotFoundError):
-        conf.load(" ")
-
-    with pytest.raises(ValueError):
-        df = pd.read_csv(file_confounds, sep="\t")
-        df = df.drop("trans_x", axis=1)
-        conf.load(df)
-
-
 def test_confounds2df():
     """Check auto-detect of confonds from an fMRI nii image."""
     conf = lc.Confounds()

--- a/load_confounds/tests/test_strategies.py
+++ b/load_confounds/tests/test_strategies.py
@@ -189,6 +189,49 @@ def test_AnatCompCor():
 
     compcor_col_str_anat = "".join(conf.columns_)
     assert "t_comp_cor_" not in compcor_col_str_anat
+    assert (
+        "a_comp_cor_57" not in compcor_col_str_anat
+    )  # this one comes from the WW mask
+
+
+def test_AnatCompCor_not_combined():
+    """Test the AnatCompCor strategy without combined mask."""
+    # Try to load the confounds, whithout PCA reduction
+    conf = lc.AnatCompCor(acompcor_combined=False)
+    conf.load(file_confounds)
+
+    # Check that the confonds is a data frame
+    assert isinstance(conf.confounds_, np.ndarray)
+
+    list_check = [
+        "trans_x",
+        "trans_y",
+        "rot_z",
+        "trans_x_derivative1",
+        "trans_x_power2",
+        "trans_y_derivative1_power2",
+        "trans_z_derivative1",
+        "trans_z_power2",
+        "trans_z_derivative1_power2",
+        "rot_y_derivative1",
+        "rot_y_power2",
+        "rot_z_power2",
+        "rot_z_derivative1_power2",
+        "cosine00",
+        "cosine01",
+        "a_comp_cor_57",  # from CSF mask
+        "a_comp_cor_58",  # from CSF mask
+        "a_comp_cor_105",  # from WM mask
+    ]
+
+    for check in list_check:
+        assert check in conf.columns_
+
+    compcor_col_str_anat = "".join(conf.columns_)
+    assert "t_comp_cor_" not in compcor_col_str_anat
+    assert (
+        "a_comp_cor_00" not in compcor_col_str_anat
+    )  # this one comes from the combined mask
 
 
 def test_TempCompCor():
@@ -216,6 +259,7 @@ def test_TempCompCor():
     compcor_col_str_anat = "".join(conf.columns_)
     assert "a_comp_cor_" not in compcor_col_str_anat
 
+
 def test_ICAAROMA():
     """Test the (non-aggressive) ICA-AROMA strategy."""
     conf = lc.ICAAROMA()
@@ -234,8 +278,9 @@ def test_ICAAROMA():
     for c in conf.columns_:
         # Check that all fixed name model categories
         fixed = c in list_check
-        cosines = re.match('cosine+', c)
+        cosines = re.match("cosine+", c)
         assert fixed or cosines
+
 
 def test_AROMAGSR():
     """Test the (non-aggressive) AROMA-GSR strategy."""
@@ -251,8 +296,9 @@ def test_AROMAGSR():
     for c in conf.columns_:
         # Check that all fixed name model categories
         fixed = c in list_check
-        cosines = re.match('cosine+', c)
+        cosines = re.match("cosine+", c)
         assert fixed or cosines
+
 
 def test_AggrICAAROMA():
     """Test the aggressive ICA-AROMA strategy."""
@@ -268,6 +314,6 @@ def test_AggrICAAROMA():
     for c in conf.columns_:
         # Check that all fixed name model categories
         fixed = c in list_check
-        cosines = re.match('cosine+', c)
-        aroma = re.match('aroma_motion_+', c)
+        cosines = re.match("cosine+", c)
+        aroma = re.match("aroma_motion_+", c)
         assert fixed or cosines or aroma


### PR DESCRIPTION
Continuing work from https://github.com/smeisler/load_confounds/tree/iss78 ... adding a test.