### PR TITLE
Refactor compcor

### DIFF
--- a/load_confounds/compcor.py
+++ b/load_confounds/compcor.py
@@ -1,0 +1,63 @@
+"""Helper function for _load_compcor"""
+
+
+prefix_compcor = {"full": ["t", "a"],
+                   "temp": ["t"],
+                   "anat": ["a"]}
+anat_masker = {True: ["combined"], False: ["WM", "CSF"], None: None}
+
+
+def _find_compcor(confounds_json, compcor, n_compcor, acompcor_combined):
+    """Builds list for the number of compcor components."""
+    prefix_set, anat_mask = _check_compcor_method(compcor, acompcor_combined)
+
+    collector = []
+    for prefix in prefix_set:
+        # all possible compcor confounds, mixing different types of mask
+        all_compcor_name = [
+            comp for comp in confounds_json.keys() if f"{prefix}_comp_cor" in comp
+        ]
+        # filter by prefix first and apply acompor mask option if relevant
+        compcor_cols_filt = _prefix_confound_filter(prefix, all_compcor_name)
+        if prefix == "a":
+            compcor_cols_filt = _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt)
+        collector += compcor_cols_filt
+    return _select_compcor(collector, n_compcor)
+
+
+def _select_compcor(compcor_cols, n_compcor):
+    """Retain a specified number of compcor components."""
+    # only select if not "auto", or less components are requested than there actually is
+    if (n_compcor != "auto") and (n_compcor < len(compcor_cols)):
+        compcor_cols = compcor_cols[0:n_compcor]
+    return compcor_cols
+
+
+def _check_compcor_method(compcor, acompcor_combined):
+    """load compcor options and check if method is acceptable"""
+    # get relevant prefix from compcor strategy
+    prefix_set = prefix_compcor[compcor]
+    # get relevant compcore mask
+    anat_mask = anat_masker[acompcor_combined]
+    if ("a" in prefix_set) and (anat_mask is None):
+        raise ValueError(f"acompcor_combined must set to True or False. Got {acompcor_combined}")
+    return prefix_set, anat_mask
+
+
+def _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt):
+    """filter according to acompcor mask"""
+    cols = []
+    for compcor_col in compcor_cols_filt:
+        if confounds_json[compcor_col]["Mask"] in anat_mask:
+            cols.append(compcor_col)
+    return cols
+
+
+def _prefix_confound_filter(prefix, all_compcor_name):
+    """get confound columns by prefix and acompcor mask"""
+    compcor_cols_filt = []
+    for nn in range(len(all_compcor_name)):
+        nn_str = str(nn).zfill(2)
+        compcor_col = f"{prefix}_comp_cor_{nn_str}"
+        compcor_cols_filt.append(compcor_col)
+    return compcor_cols_filt

--- a/load_confounds/confounds.py
+++ b/load_confounds/confounds.py
@@ -11,12 +11,6 @@ import os
 import json
 
 
-prefix_compcor = {"full": ["t", "a"],
-                   "temp": ["t"],
-                   "anat": ["a"]}
-anat_masker = {True: ["combined"], False: ["WM", "CSF"], None: None}
-
-
 def _check_params(confounds_raw, params):
     """Check that specified parameters can be found in the confounds."""
     not_found_params = []
@@ -43,63 +37,6 @@ def _find_confounds(confounds_raw, keywords):
     if missing_keys:
         raise MissingConfound(keywords=missing_keys)
     return list_confounds
-
-
-def _select_compcor(compcor_cols, n_compcor):
-    """Retain a specified number of compcor components."""
-    # only select if not "auto", or less components are requested than there actually is
-    if (n_compcor != "auto") and (n_compcor < len(compcor_cols)):
-        compcor_cols = compcor_cols[0:n_compcor]
-    return compcor_cols
-
-
-def _check_compcor_method(compcor, acompcor_combined):
-    """load compcor options and check if method is acceptable"""
-    # get relevant prefix from compcor strategy
-    prefix_set = prefix_compcor[compcor]
-    # get relevant compcore mask
-    anat_mask = anat_masker[acompcor_combined]
-    if ("a" in prefix_set) and (anat_mask is None):
-        raise ValueError(f"acompcor_combined must set to True or False. Got {acompcor_combined}")
-    return prefix_set, anat_mask
-
-
-def _find_compcor(confounds_json, compcor, n_compcor, acompcor_combined):
-    """Builds list for the number of compcor components."""
-    prefix_set, anat_mask = _check_compcor_method(compcor, acompcor_combined)
-
-    collector = []
-    for prefix in prefix_set:
-        # all possible compcor confounds, mixing different types of mask
-        all_compcor_name = [
-            comp for comp in confounds_json.keys() if f"{prefix}_comp_cor" in comp
-        ]
-        # filter by prefix first and apply acompor mask option if relevant
-        compcor_cols_filt = _prefix_confound_filter(prefix, all_compcor_name)
-        if prefix == "a":
-            compcor_cols_filt = _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt)
-        collector += compcor_cols_filt
-    return _select_compcor(collector, n_compcor)
-
-
-def _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt):
-    """filter according to acompcor mask"""
-    cols = []
-    for compcor_col in compcor_cols_filt:
-        if confounds_json[compcor_col]["Mask"] in anat_mask:
-            cols.append(compcor_col)
-    return cols
-
-
-def _prefix_confound_filter(prefix, all_compcor_name):
-    """get confound columns by prefix and acompcor mask"""
-    compcor_cols_filt = []
-    for nn in range(len(all_compcor_name)):
-        nn_str = str(nn).zfill(2)
-        compcor_col = f"{prefix}_comp_cor_{nn_str}"
-        compcor_cols_filt.append(compcor_col)
-    return compcor_cols_filt
-
 
 
 def _sanitize_confounds(confounds_raw):

--- a/load_confounds/confounds.py
+++ b/load_confounds/confounds.py
@@ -14,7 +14,7 @@ import json
 prefix_compcor = {"full": ["t", "a"],
                    "temp": ["t"],
                    "anat": ["a"]}
-anat_masker = {True: ["combined"], False: ["WM", "CSF"]}
+anat_masker = {True: ["combined"], False: ["WM", "CSF"], None: None}
 
 
 def _check_params(confounds_raw, params):
@@ -53,12 +53,20 @@ def _select_compcor(compcor_cols, n_compcor):
     return compcor_cols
 
 
-def _find_compcor(confounds_json, compcor, n_compcor, acompcor_combined):
-    """Builds list for the number of compcor components."""
+def _check_compcor_method(compcor, acompcor_combined):
+    """load compcor options and check if method is acceptable"""
     # get relevant prefix from compcor strategy
     prefix_set = prefix_compcor[compcor]
     # get relevant compcore mask
     anat_mask = anat_masker[acompcor_combined]
+    if ("a" in prefix_set) and (anat_mask is None):
+        raise ValueError(f"acompcor_combined must set to True or False. Got {acompcor_combined}")
+    return prefix_set, anat_mask
+
+
+def _find_compcor(confounds_json, compcor, n_compcor, acompcor_combined):
+    """Builds list for the number of compcor components."""
+    prefix_set, anat_mask = _check_compcor_method(compcor, acompcor_combined)
 
     collector = []
     for prefix in prefix_set:
@@ -66,8 +74,10 @@ def _find_compcor(confounds_json, compcor, n_compcor, acompcor_combined):
         all_compcor_name = [
             comp for comp in confounds_json.keys() if f"{prefix}_comp_cor" in comp
         ]
-        # filter by prefix first and acompor mask option if relevant
-        compcor_cols_filt = _prefix_confound_filter(prefix, all_compcor_name, confounds_json, anat_mask)
+        # filter by prefix first and apply acompor mask option if relevant
+        compcor_cols_filt = _prefix_confound_filter(prefix, all_compcor_name)
+        if prefix == "a":
+            compcor_cols_filt = _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt)
         collector += compcor_cols_filt
     return _select_compcor(collector, n_compcor)
 
@@ -81,17 +91,15 @@ def _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt):
     return cols
 
 
-def _prefix_confound_filter(prefix, all_compcor_name, confounds_json, anat_mask):
+def _prefix_confound_filter(prefix, all_compcor_name):
     """get confound columns by prefix and acompcor mask"""
     compcor_cols_filt = []
     for nn in range(len(all_compcor_name)):
         nn_str = str(nn).zfill(2)
         compcor_col = f"{prefix}_comp_cor_{nn_str}"
         compcor_cols_filt.append(compcor_col)
-    if prefix == "t":
-        return compcor_cols_filt
-    else:
-        return _acompcor_mask(confounds_json, anat_mask, compcor_cols_filt)
+    return compcor_cols_filt
+
 
 
 def _sanitize_confounds(confounds_raw):

--- a/load_confounds/parser.py
+++ b/load_confounds/parser.py
@@ -5,6 +5,7 @@ Authors: load_confounds team
 import numpy as np
 import pandas as pd
 from . import confounds as cf
+from .compcor import _find_compcor
 
 # Global variables listing the admissible types of noise components
 all_confounds = [
@@ -268,7 +269,7 @@ class Confounds:
 
     def _load_compcor(self, confounds_raw):
         """Load compcor regressors."""
-        compcor_cols = cf._find_compcor(
+        compcor_cols = _find_compcor(
                     self.json_, self.compcor, self.n_compcor, self.acompcor_combined
                 )
         cf._check_params(confounds_raw, compcor_cols)

--- a/load_confounds/parser.py
+++ b/load_confounds/parser.py
@@ -268,15 +268,7 @@ class Confounds:
 
     def _load_compcor(self, confounds_raw):
         """Load compcor regressors."""
-        if self.compcor == "full":
-            compcor_cols = cf._find_compcor(
-                self.json_, "anat", self.n_compcor, self.acompcor_combined
-            )
-            compcor_cols.extend(
-                cf.find_compcor(self.json_, "temp", self.n_compcor, self.acompcor_combined)
-            )
-        else:
-            compcor_cols = cf._find_compcor(
+        compcor_cols = cf._find_compcor(
                     self.json_, self.compcor, self.n_compcor, self.acompcor_combined
                 )
         cf._check_params(confounds_raw, compcor_cols)

--- a/load_confounds/parser.py
+++ b/load_confounds/parser.py
@@ -268,26 +268,17 @@ class Confounds:
 
     def _load_compcor(self, confounds_raw):
         """Load compcor regressors."""
-        if self.compcor == "anat":
-            compcor_cols = cf._find_acompcor(
-                self.json_, self.n_compcor, self.acompcor_combined
-            )
-
-        if self.compcor == "temp":
-            compcor_cols = cf._find_compcor(
-                self.json_, "t", self.n_compcor, self.acompcor_combined
-            )
-
         if self.compcor == "full":
             compcor_cols = cf._find_compcor(
-                self.json_, "a", self.n_compcor, self.acompcor_combined
+                self.json_, "anat", self.n_compcor, self.acompcor_combined
             )
             compcor_cols.extend(
-                cf._find_compcor(
-                    self.json_, "t", self.n_compcor, self.acompcor_combined
-                )
+                cf.find_compcor(self.json_, "temp", self.n_compcor, self.acompcor_combined)
             )
-
+        else:
+            compcor_cols = cf._find_compcor(
+                    self.json_, self.compcor, self.n_compcor, self.acompcor_combined
+                )
         cf._check_params(confounds_raw, compcor_cols)
         return confounds_raw[compcor_cols]
 

--- a/load_confounds/tests/test_parser.py
+++ b/load_confounds/tests/test_parser.py
@@ -301,8 +301,8 @@ def test_not_found_exception():
         conf.load(file_confounds)
 
     # catch invalid compcor option
-    with pytest.raises(KeyError):
-        conf = lc.Confounds(strategy=["compcor"], compcor="anat", acompcor_combined=None)
+    with pytest.raises(ValueError):
+        conf = lc.Confounds(strategy=["compcor"], compcor="full", acompcor_combined=None)
         conf.load(file_confounds)
 
 

--- a/load_confounds/tests/test_parser.py
+++ b/load_confounds/tests/test_parser.py
@@ -295,6 +295,16 @@ def test_not_found_exception():
         conf = lc.Confounds(strategy=["compcor"], compcor="anat")
         conf.load(file_missing_confounds)
 
+    # catch invalid compcor option
+    with pytest.raises(KeyError):
+        conf = lc.Confounds(strategy=["compcor"], compcor="blah")
+        conf.load(file_confounds)
+
+    # catch invalid compcor option
+    with pytest.raises(KeyError):
+        conf = lc.Confounds(strategy=["compcor"], compcor="anat", acompcor_combined=None)
+        conf.load(file_confounds)
+
 
 def test_ica_aroma():
     conf = lc.Confounds(strategy=["ica_aroma"])


### PR DESCRIPTION
Not sure if this will increase the complexity or reduce it.

 - compcor option and anatomical mask all resolved in `_find_compcor`
 - Use a dictionary to catch invalid input
 - Catch invalid input for compcor and acompcor_combined, and invalid combinations of the two

Feel free to reject/merge to see if this fits your plan.